### PR TITLE
return worker from initializeWorker

### DIFF
--- a/packages/msw-addon/src/mswDecorator.js
+++ b/packages/msw-addon/src/mswDecorator.js
@@ -7,6 +7,7 @@ export function initializeWorker(options) {
   if (typeof global.process === 'undefined') {
     worker = setupWorker();
     worker.start(options);
+    return worker
   }
 }
 


### PR DESCRIPTION
Hi there!

When I set up my worker in `.storybook/preview.js`, I would like to add some global configuration for my worker.

Currently that's not possible because the worker created by `initializeWorker` is not returned. 

I think this should be a low impact change, but please let me know if there's anything worth testing or figuring out 😀