### PR TITLE
chore: update all stories to CSF hoisted format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,17 @@ import { rest } from 'msw';
 
 export const SuccessBehavior = () => <UserProfile />;
 
-SuccessBehavior.story = {
-  parameters: {
-    msw: [
-      rest.get('/user', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            firstName: 'Neil',
-            lastName: 'Maverick',
-          }),
-        );
-      }),
-    ]
-  },
+SuccessBehavior.parameters = {
+  msw: [
+    rest.get('/user', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          firstName: 'Neil',
+          lastName: 'Maverick',
+        }),
+      );
+    }),
+  ]
 };
 ```
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -31,6 +31,16 @@
     "extends": [
       "react-app",
       "react-app/jest"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "src/**/*.stories.js"
+        ],
+        "rules": {
+          "import/no-anonymous-default-export": "off"
+        }
+      }
     ]
   },
   "browserslist": {

--- a/packages/docs/src/demos/apollo/App.stories.js
+++ b/packages/docs/src/demos/apollo/App.stories.js
@@ -3,12 +3,10 @@ import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
 import { graphql } from 'msw';
 import { App } from './App';
 
-const config = {
+export default {
   title: 'Demos/Apollo',
   component: App,
 };
-
-export default config;
 
 const defaultClient = new ApolloClient({
   uri: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
@@ -61,36 +59,32 @@ const films = [
 ];
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      graphql.query('AllFilmsQuery', (req, res, ctx) => {
-        return res(
-          ctx.data({
-            allFilms: {
-              films,
-            },
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    graphql.query('AllFilmsQuery', (req, res, ctx) => {
+      return res(
+        ctx.data({
+          allFilms: {
+            films,
+          },
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedError = MockTemplate.bind({});
-MockedError.story = {
-  parameters: {
-    msw: [
-      graphql.query('AllFilmsQuery', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.errors([
-            {
-              message: 'Access denied',
-            },
-          ]),
-        );
-      }),
-    ],
-  },
+MockedError.parameters = {
+  msw: [
+    graphql.query('AllFilmsQuery', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.errors([
+          {
+            message: 'Access denied',
+          },
+        ]),
+      );
+    }),
+  ],
 };

--- a/packages/docs/src/demos/apollo/App.test.js
+++ b/packages/docs/src/demos/apollo/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories';
 const server = getServer();
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.story.parameters.msw);
+  server.use(...MockedSuccess.parameters.msw);
   render(<MockedSuccess />);
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument();
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 });
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.story.parameters.msw);
+  server.use(...MockedError.parameters.msw);
   render(<MockedError />);
 
   const errorMsgNode = await screen.findByText(/could not fetch star wars data/i);

--- a/packages/docs/src/demos/axios/App.stories.js
+++ b/packages/docs/src/demos/axios/App.stories.js
@@ -2,12 +2,10 @@ import React from 'react';
 import { rest } from 'msw';
 import { App } from './App';
 
-const config = {
+export default {
   title: 'Demos/Axios',
   component: App,
 };
-
-export default config;
 
 export const DefaultBehavior = () => <App />;
 
@@ -32,30 +30,26 @@ const films = [
 ];
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            results: films,
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: films,
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedError = MockTemplate.bind({});
-MockedError.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.status(403),
-        );
-      }),
-    ],
-  },
+MockedError.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.status(403),
+      );
+    }),
+  ],
 };

--- a/packages/docs/src/demos/axios/App.test.js
+++ b/packages/docs/src/demos/axios/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories';
 const server = getServer();
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.story.parameters.msw);
+  server.use(...MockedSuccess.parameters.msw);
   render(<MockedSuccess />);
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument();
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 });
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.story.parameters.msw);
+  server.use(...MockedError.parameters.msw);
   render(<MockedError />);
 
   const errorMsgNode = await screen.findByText(/could not fetch star wars data/i);

--- a/packages/docs/src/demos/fetch/App.stories.js
+++ b/packages/docs/src/demos/fetch/App.stories.js
@@ -2,12 +2,10 @@ import React from 'react';
 import { rest } from 'msw';
 import { App } from './App';
 
-const config = {
+export default {
   title: 'Demos/Fetch',
   component: App,
 };
-
-export default config;
 
 export const DefaultBehavior = () => <App />;
 
@@ -32,30 +30,26 @@ const films = [
 ];
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            results: films,
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: films,
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedError = MockTemplate.bind({});
-MockedError.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.status(403),
-        );
-      }),
-    ],
-  },
+MockedError.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.status(403),
+      );
+    }),
+  ],
 };

--- a/packages/docs/src/demos/fetch/App.test.js
+++ b/packages/docs/src/demos/fetch/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories';
 const server = getServer();
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.story.parameters.msw);
+  server.use(...MockedSuccess.parameters.msw);
   render(<MockedSuccess />);
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument();
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 });
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.story.parameters.msw);
+  server.use(...MockedError.parameters.msw);
   render(<MockedError />);
 
   const errorMsgNode = await screen.findByText(/could not fetch star wars data/i);

--- a/packages/docs/src/demos/react-query/App.stories.js
+++ b/packages/docs/src/demos/react-query/App.stories.js
@@ -3,12 +3,10 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { rest } from 'msw';
 import { App } from './App';
 
-const config = {
+export default {
   title: 'Demos/React Query',
   component: App,
 };
-
-export default config;
 
 const defaultQueryClient = new QueryClient();
 
@@ -51,30 +49,26 @@ const films = [
 ];
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            results: films,
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: films,
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedError = MockTemplate.bind({});
-MockedError.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.status(403),
-        );
-      }),
-    ],
-  },
+MockedError.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.status(403),
+      );
+    }),
+  ],
 };

--- a/packages/docs/src/demos/react-query/App.test.js
+++ b/packages/docs/src/demos/react-query/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories';
 const server = getServer();
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.story.parameters.msw);
+  server.use(...MockedSuccess.parameters.msw);
   render(<MockedSuccess />);
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument();
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 });
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.story.parameters.msw);
+  server.use(...MockedError.parameters.msw);
   render(<MockedError />);
 
   const errorMsgNode = await screen.findByText(/could not fetch star wars data/i);

--- a/packages/docs/src/demos/react-router-react-query/App.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/App.stories.js
@@ -4,12 +4,10 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { rest } from 'msw';
 import { App } from './App';
 
-const config = {
+export default {
   title: 'Demos/React Router + RQ',
   component: App,
 };
-
-export default config;
 
 const defaultQueryClient = new QueryClient();
 
@@ -36,102 +34,100 @@ export const MockedApp = () => (
     </Router>
   </QueryClientProvider>
 );
-MockedApp.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            results: [
-              {
-                title: '(Mocked) A New Hope',
-                episode_id: 4,
-                release_date: '1977-05-25',
-                url: 'http://swapi.dev/api/films/1/',
-              },
-              {
-                title: '(Mocked) Empire Strikes Back',
-                episode_id: 5,
-                release_date: '1980-05-17',
-                url: 'http://swapi.dev/api/films/2/',
-              },
-            ],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            title: '(Mocked) A New Hope',
-            episode_id: 4,
-            opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
-            characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/films/2', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            title: '(Mocked) Empire Strikes Back',
-            episode_id: 5,
-            opening_crawl: `Imperial troops are pursuing the Rebel forces across the galaxy.`,
-            characters: ['http://swapi.dev/api/people/1/'],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            results: [
-              {
-                name: '(Mocked) Luke Skywalker',
-                url: 'http://swapi.dev/api/people/1/',
-              },
-              {
-                name: '(Mocked) C-3PO',
-                url: 'http://swapi.dev/api/people/2/',
-              },
-            ],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) Luke Skywalker',
-            birth_year: '19BBY',
-            eye_color: 'blue',
-            hair_color: 'blond',
-            height: '172',
-            mass: '77',
-            homeworld: 'http://swapi.dev/api/planets/1/',
-            films: ['http://swapi.dev/api/films/1/', 'http://swapi.dev/api/films/2/'],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) C-3PO',
-            birth_year: '112BBY',
-            eye_color: 'yellow',
-            hair_color: 'n/a',
-            height: '167',
-            mass: '75',
-            homeworld: 'http://swapi.dev/api/planets/1/',
-            films: ['http://swapi.dev/api/films/1/'],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) Tatooine',
-          }),
-        );
-      }),
-    ],
-  },
+MockedApp.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: [
+            {
+              title: '(Mocked) A New Hope',
+              episode_id: 4,
+              release_date: '1977-05-25',
+              url: 'http://swapi.dev/api/films/1/',
+            },
+            {
+              title: '(Mocked) Empire Strikes Back',
+              episode_id: 5,
+              release_date: '1980-05-17',
+              url: 'http://swapi.dev/api/films/2/',
+            },
+          ],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          title: '(Mocked) A New Hope',
+          episode_id: 4,
+          opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
+          characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/films/2', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          title: '(Mocked) Empire Strikes Back',
+          episode_id: 5,
+          opening_crawl: `Imperial troops are pursuing the Rebel forces across the galaxy.`,
+          characters: ['http://swapi.dev/api/people/1/'],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: [
+            {
+              name: '(Mocked) Luke Skywalker',
+              url: 'http://swapi.dev/api/people/1/',
+            },
+            {
+              name: '(Mocked) C-3PO',
+              url: 'http://swapi.dev/api/people/2/',
+            },
+          ],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) Luke Skywalker',
+          birth_year: '19BBY',
+          eye_color: 'blue',
+          hair_color: 'blond',
+          height: '172',
+          mass: '77',
+          homeworld: 'http://swapi.dev/api/planets/1/',
+          films: ['http://swapi.dev/api/films/1/', 'http://swapi.dev/api/films/2/'],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) C-3PO',
+          birth_year: '112BBY',
+          eye_color: 'yellow',
+          hair_color: 'n/a',
+          height: '167',
+          mass: '75',
+          homeworld: 'http://swapi.dev/api/planets/1/',
+          films: ['http://swapi.dev/api/films/1/'],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) Tatooine',
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedFilmSubsection = () => (
@@ -141,47 +137,45 @@ export const MockedFilmSubsection = () => (
     </Router>
   </QueryClientProvider>
 );
-MockedFilmSubsection.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            title: '(Mocked) A New Hope',
-            episode_id: 4,
-            opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
-            characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) Luke Skywalker',
-            birth_year: '19BBY',
-            eye_color: 'blue',
-            hair_color: 'blond',
-            height: '172',
-            mass: '77',
-            homeworld: 'http://swapi.dev/api/planets/1/',
-            films: ['http://swapi.dev/api/films/1/', 'http://swapi.dev/api/films/2/'],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) C-3PO',
-            birth_year: '112BBY',
-            eye_color: 'yellow',
-            hair_color: 'n/a',
-            height: '167',
-            mass: '75',
-            homeworld: 'http://swapi.dev/api/planets/1/',
-            films: ['http://swapi.dev/api/films/1/'],
-          }),
-        );
-      }),
-    ],
-  },
-}
+MockedFilmSubsection.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          title: '(Mocked) A New Hope',
+          episode_id: 4,
+          opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
+          characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) Luke Skywalker',
+          birth_year: '19BBY',
+          eye_color: 'blue',
+          hair_color: 'blond',
+          height: '172',
+          mass: '77',
+          homeworld: 'http://swapi.dev/api/planets/1/',
+          films: ['http://swapi.dev/api/films/1/', 'http://swapi.dev/api/films/2/'],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) C-3PO',
+          birth_year: '112BBY',
+          eye_color: 'yellow',
+          hair_color: 'n/a',
+          height: '167',
+          mass: '75',
+          homeworld: 'http://swapi.dev/api/planets/1/',
+          films: ['http://swapi.dev/api/films/1/'],
+        }),
+      );
+    }),
+  ],
+};

--- a/packages/docs/src/demos/react-router-react-query/pages/character/Character.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/pages/character/Character.stories.js
@@ -4,12 +4,10 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { rest } from 'msw';
 import Character from './Character';
 
-const config = {
+export default {
   title: 'Demos/React Router + RQ/Page Stories/Character',
   component: Character,
 };
-
-export default config;
 
 const defaultQueryClient = new QueryClient();
 
@@ -75,29 +73,25 @@ const MockTemplate = () => (
 );
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      ...commonMockHandlers,
-      rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) Tatooine',
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    ...commonMockHandlers,
+    rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) Tatooine',
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedPlanetsApiError = MockTemplate.bind({});
-MockedPlanetsApiError.story = {
-  parameters: {
-    msw: [
-      ...commonMockHandlers,
-      rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
-        return res(ctx.delay(800), ctx.status(403));
-      }),
-    ],
-  },
+MockedPlanetsApiError.parameters = {
+  msw: [
+    ...commonMockHandlers,
+    rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
+      return res(ctx.delay(800), ctx.status(403));
+    }),
+  ],
 };

--- a/packages/docs/src/demos/react-router-react-query/pages/characters/Characters.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/pages/characters/Characters.stories.js
@@ -4,12 +4,10 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { rest } from 'msw';
 import Characters from './Characters';
 
-const config = {
+export default {
   title: 'Demos/React Router + RQ/Page Stories/Characters',
   component: Characters,
 };
-
-export default config;
 
 const defaultQueryClient = new QueryClient();
 
@@ -42,39 +40,35 @@ const MockTemplate = () => (
 );
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            results: [
-              {
-                name: '(Mocked) Luke Skywalker',
-                url: 'http://swapi.dev/api/people/1/',
-              },
-              {
-                name: '(Mocked) C-3PO',
-                url: 'http://swapi.dev/api/people/2/',
-              },
-            ],
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: [
+            {
+              name: '(Mocked) Luke Skywalker',
+              url: 'http://swapi.dev/api/people/1/',
+            },
+            {
+              name: '(Mocked) C-3PO',
+              url: 'http://swapi.dev/api/people/2/',
+            },
+          ],
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedError = MockTemplate.bind({});
-MockedError.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.status(403),
-        );
-      }),
-    ],
-  },
+MockedError.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.status(403),
+      );
+    }),
+  ],
 };

--- a/packages/docs/src/demos/react-router-react-query/pages/film/Film.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/pages/film/Film.stories.js
@@ -4,12 +4,10 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { rest } from 'msw';
 import Film from './Film';
 
-const config = {
+export default {
   title: 'Demos/React Router + RQ/Page Stories/Film',
   component: Film,
 };
-
-export default config;
 
 const defaultQueryClient = new QueryClient();
 
@@ -42,78 +40,72 @@ const MockTemplate = () => (
 );
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            title: '(Mocked) A New Hope',
-            episode_id: 4,
-            opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
-            characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) Luke Skywalker',
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) C-3PO',
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          title: '(Mocked) A New Hope',
+          episode_id: 4,
+          opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
+          characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) Luke Skywalker',
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) C-3PO',
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedFilmApiError = MockTemplate.bind({});
-MockedFilmApiError.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.status(403),
-        );
-      }),
-    ],
-  },
+MockedFilmApiError.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.status(403),
+      );
+    }),
+  ],
 };
 
 export const MockedCharacterApiError = MockTemplate.bind({});
-MockedCharacterApiError.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            title: '(Mocked) A New Hope',
-            episode_id: 4,
-            opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
-            characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
-          }),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.status(403),
-        );
-      }),
-      rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            name: '(Mocked) C-3PO',
-          }),
-        );
-      }),
-    ],
-  },
+MockedCharacterApiError.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          title: '(Mocked) A New Hope',
+          episode_id: 4,
+          opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
+          characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
+        }),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.status(403),
+      );
+    }),
+    rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          name: '(Mocked) C-3PO',
+        }),
+      );
+    }),
+  ],
 };

--- a/packages/docs/src/demos/react-router-react-query/pages/films/Films.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/pages/films/Films.stories.js
@@ -4,12 +4,10 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { rest } from 'msw';
 import Films from './Films';
 
-const config = {
+export default {
   title: 'Demos/React Router + RQ/Page Stories/Films',
   component: Films,
 };
-
-export default config;
 
 const defaultQueryClient = new QueryClient();
 
@@ -42,43 +40,39 @@ const MockTemplate = () => (
 );
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            results: [
-              {
-                title: '(Mocked) A New Hope',
-                episode_id: 4,
-                release_date: '1977-05-25',
-                url: 'http://swapi.dev/api/films/1/',
-              },
-              {
-                title: '(Mocked) Empire Strikes Back',
-                episode_id: 5,
-                release_date: '1980-05-17',
-                url: 'http://swapi.dev/api/films/2/',
-              },
-            ],
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: [
+            {
+              title: '(Mocked) A New Hope',
+              episode_id: 4,
+              release_date: '1977-05-25',
+              url: 'http://swapi.dev/api/films/1/',
+            },
+            {
+              title: '(Mocked) Empire Strikes Back',
+              episode_id: 5,
+              release_date: '1980-05-17',
+              url: 'http://swapi.dev/api/films/2/',
+            },
+          ],
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedError = MockTemplate.bind({});
-MockedError.story = {
-  parameters: {
-    msw: [
-      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.status(403),
-        );
-      }),
-    ],
-  },
+MockedError.parameters = {
+  msw: [
+    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.status(403),
+      );
+    }),
+  ],
 };

--- a/packages/docs/src/demos/urql/App.stories.js
+++ b/packages/docs/src/demos/urql/App.stories.js
@@ -3,12 +3,10 @@ import { createClient, Provider } from 'urql';
 import { graphql } from 'msw';
 import { App } from './App';
 
-const config = {
+export default {
   title: 'Demos/Urql',
   component: App,
 };
-
-export default config;
 
 const defaultClient = createClient({
   url: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
@@ -50,36 +48,32 @@ const films = [
 ];
 
 export const MockedSuccess = MockTemplate.bind({});
-MockedSuccess.story = {
-  parameters: {
-    msw: [
-      graphql.query('AllFilmsQuery', (req, res, ctx) => {
-        return res(
-          ctx.data({
-            allFilms: {
-              films,
-            },
-          }),
-        );
-      }),
-    ],
-  },
+MockedSuccess.parameters = {
+  msw: [
+    graphql.query('AllFilmsQuery', (req, res, ctx) => {
+      return res(
+        ctx.data({
+          allFilms: {
+            films,
+          },
+        }),
+      );
+    }),
+  ],
 };
 
 export const MockedError = MockTemplate.bind({});
-MockedError.story = {
-  parameters: {
-    msw: [
-      graphql.query('AllFilmsQuery', (req, res, ctx) => {
-        return res(
-          ctx.delay(800),
-          ctx.errors([
-            {
-              message: 'Access denied',
-            },
-          ]),
-        );
-      }),
-    ],
-  },
+MockedError.parameters = {
+  msw: [
+    graphql.query('AllFilmsQuery', (req, res, ctx) => {
+      return res(
+        ctx.delay(800),
+        ctx.errors([
+          {
+            message: 'Access denied',
+          },
+        ]),
+      );
+    }),
+  ],
 };

--- a/packages/docs/src/demos/urql/App.test.js
+++ b/packages/docs/src/demos/urql/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories';
 const server = getServer();
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.story.parameters.msw);
+  server.use(...MockedSuccess.parameters.msw);
   render(<MockedSuccess />);
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument();
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 });
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.story.parameters.msw);
+  server.use(...MockedError.parameters.msw);
   render(<MockedError />);
 
   const errorMsgNode = await screen.findByText(/could not fetch star wars data/i);

--- a/packages/docs/src/guides/installation.stories.mdx
+++ b/packages/docs/src/guides/installation.stories.mdx
@@ -45,19 +45,17 @@ import { rest } from 'msw';
 
 export const SuccessBehavior = () => <UserProfile />;
 
-SuccessBehavior.story = {
-  parameters: {
-    msw: [
-      rest.get('/user', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            firstName: 'Neil',
-            lastName: 'Maverick',
-          }),
-        );
-      }),
-    ]
-  },
+SuccessBehavior.parameters = {
+  msw: [
+    rest.get('/user', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          firstName: 'Neil',
+          lastName: 'Maverick',
+        }),
+      );
+    }),
+  ]
 };
 ```
 

--- a/packages/docs/src/guides/introduction.stories.mdx
+++ b/packages/docs/src/guides/introduction.stories.mdx
@@ -17,19 +17,17 @@ import { rest } from 'msw';
 
 export const SuccessBehavior = () => <UserProfile />;
 
-SuccessBehavior.story = {
-  parameters: {
-    msw: [
-      rest.get('/user', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            firstName: 'Neil',
-            lastName: 'Maverick',
-          }),
-        );
-      }),
-    ]
-  },
+SuccessBehavior.parameters = {
+  msw: [
+    rest.get('/user', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          firstName: 'Neil',
+          lastName: 'Maverick',
+        }),
+      );
+    }),
+  ]
 };
 ```
 

--- a/packages/msw-addon/README.md
+++ b/packages/msw-addon/README.md
@@ -50,19 +50,17 @@ import { rest } from 'msw';
 
 export const SuccessBehavior = () => <UserProfile />;
 
-SuccessBehavior.story = {
-  parameters: {
-    msw: [
-      rest.get('/user', (req, res, ctx) => {
-        return res(
-          ctx.json({
-            firstName: 'Neil',
-            lastName: 'Maverick',
-          }),
-        );
-      }),
-    ]
-  },
+SuccessBehavior.parameters = {
+  msw: [
+    rest.get('/user', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          firstName: 'Neil',
+          lastName: 'Maverick',
+        }),
+      );
+    }),
+  ]
 };
 ```
 


### PR DESCRIPTION
This PR updates the stories files (as well as tests and documentation examples) to use [hoisted CSF](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#hoisted-csf-annotations) annotation which is the standard format since Storybook 6.