### PR TITLE
Add support for setting default requestHandlers

### DIFF
--- a/packages/msw-addon/src/mswDecorator.js
+++ b/packages/msw-addon/src/mswDecorator.js
@@ -3,9 +3,9 @@ import { setupWorker } from 'msw';
 
 let worker;
 
-export function initializeWorker(options) {
+export function initializeWorker(options, requestHandlers) {
   if (typeof global.process === 'undefined') {
-    worker = setupWorker();
+    worker = setupWorker(requestHandlers);
     worker.start(options);
   }
 }

--- a/packages/msw-addon/src/mswDecorator.js
+++ b/packages/msw-addon/src/mswDecorator.js
@@ -3,7 +3,7 @@ import { setupWorker } from 'msw';
 
 let worker;
 
-export function initializeWorker(options, requestHandlers) {
+export function initializeWorker(options, requestHandlers = []) {
   if (typeof global.process === 'undefined') {
     worker = setupWorker(...requestHandlers);
     worker.start(options);

--- a/packages/msw-addon/src/mswDecorator.js
+++ b/packages/msw-addon/src/mswDecorator.js
@@ -5,7 +5,7 @@ let worker;
 
 export function initializeWorker(options, requestHandlers) {
   if (typeof global.process === 'undefined') {
-    worker = setupWorker(requestHandlers);
+    worker = setupWorker(...requestHandlers);
     worker.start(options);
   }
 }


### PR DESCRIPTION
I'd like to be able to pass default requestHandlers to `setupWorker` that remain set when the decorators calls `resetHandlers` before each story.