### PR TITLE
setup netlify to redirect to vercel

### DIFF
--- a/packages/docs/netlify.toml
+++ b/packages/docs/netlify.toml
@@ -1,0 +1,7 @@
+# We have moved to Vercel for deploying the docs.
+# This netlify config redirects traffic from old site to the new site.
+
+[[redirects]]
+  from = "/*"
+  to = "https://msw-sb.vercel.app"
+  force = true


### PR DESCRIPTION
Setup Netlify redirect config so that when user visits `https://msw-sb.netlify.app/?path=/story/demos-axios--default-behavior` they are redirected to `https://msw-sb.vercel.app/?path=/story/demos-axios--default-behavior`.

Since we've removed Netlify integration from the repo, I've tested this using Netlify CLI. Try it out on 

https://60c97e618c2fb05148d83d8b--msw-sb.netlify.app