### PR TITLE
Failsafe environment check

### DIFF
--- a/packages/msw-addon/package.json
+++ b/packages/msw-addon/package.json
@@ -30,7 +30,8 @@
   "homepage": "https://msw-sb.vercel.app/",
   "license": "MIT",
   "dependencies": {
-    "@storybook/addons": "^6.0.0"
+    "@storybook/addons": "^6.0.0",
+    "is-node-process": "^1.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/msw-addon/src/mswDecorator.js
+++ b/packages/msw-addon/src/mswDecorator.js
@@ -1,6 +1,11 @@
 let api
+let IS_BROWSER
 
-const IS_BROWSER = typeof global.process === 'undefined'
+try {
+  IS_BROWSER = typeof global.process === 'undefined'
+} catch (e) {
+  IS_BROWSER = true
+}
 
 export function initializeWorker(options) {
   console.warn(

--- a/packages/msw-addon/src/mswDecorator.js
+++ b/packages/msw-addon/src/mswDecorator.js
@@ -1,11 +1,7 @@
-let api
-let IS_BROWSER
+import { isNodeProcess } from 'is-node-process'
 
-try {
-  IS_BROWSER = typeof global.process === 'undefined'
-} catch (e) {
-  IS_BROWSER = true
-}
+const IS_BROWSER = !isNodeProcess()
+let api
 
 export function initializeWorker(options) {
   console.warn(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8769,6 +8769,11 @@ is-negative-zero@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
 
+is-node-process@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.0.1.tgz#4fc7ac3a91e8aac58175fe0578abbc56f2831b23"
+  integrity sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"


### PR DESCRIPTION
Using `esbuild` with Storybook leads to a failure using this add-on. This is because `esbuild` is a lot more strict and close to the spec.

This is the error : 
> Uncaught ReferenceError: global is not defined

To fix that I simply wrapper the check around a `try/catch`.