### PR TITLE
Add support for inheriting handlers from preview.js

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/msw-storybook-addon.iml" filepath="$PROJECT_DIR$/.idea/msw-storybook-addon.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/msw-storybook-addon.iml
+++ b/.idea/msw-storybook-addon.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -28,4 +28,70 @@ SuccessBehavior.parameters = {
 }
 ```
 
+You can also use an object with named handlers or named arrays of handlers, to inherit (and optionally overwrite/disable) handlers from preview.js.
+
+```js
+
+//preview.js
+export const parameters = {
+    msw: {
+        auth: [
+            rest.get('/login', (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        success: true,
+                    })
+                )
+            }),
+            rest.get('/logout', (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        success: true,
+                    })
+                )
+            }),
+        ],
+    }
+};
+
+
+// story will include the auth handlers from preview.js
+SuccessBehavior.parameters = {
+  msw: {
+      profile: rest.get('/profile', (req, res, ctx) => {
+          return res(
+              ctx.json({
+                  firstName: 'Neil',
+                  lastName: 'Maverick',
+              })
+          )
+      }),
+  }
+}
+
+// story will overwrite the auth handlers from preview.js
+FailureBehavior.parameters = {
+    msw: {
+        auth: rest.get('/login', (req, res, ctx) => {
+            return res(ctx.status(403))
+        }),
+    }
+}
+
+// story will disable the auth handlers from preview.js
+NoAuthBehavior.parameters = {
+    msw: {
+        auth: null,
+        others: [
+            rest.get('/numbers', (req, res, ctx) => {
+                return res(ctx.json([1, 2, 3]))
+            }),
+            rest.get('/strings', (req, res, ctx) => {
+                return res(ctx.json(['a', 'b', 'c']))
+            }),
+        ],
+    }
+}
+```
+
 [Full Documentation](https://msw-sb.vercel.app/)

--- a/packages/msw-addon/README.md
+++ b/packages/msw-addon/README.md
@@ -65,3 +65,69 @@ SuccessBehavior.parameters = {
 ```
 
 The msw parameter takes an array of handlers as shown in [MSW official guide](https://mswjs.io/docs/getting-started/mocks/rest-api).
+
+The msw parameter can also be an object with named handlers or named arrays of handlers, to inherit (and optionally overwrite/disable) handlers from preview.js.
+
+```js
+
+//preview.js
+export const parameters = {
+    msw: {
+        auth: [
+            rest.get('/login', (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        success: true,
+                    })
+                )
+            }),
+            rest.get('/logout', (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        success: true,
+                    })
+                )
+            }),
+        ],
+    }
+};
+
+
+// story will include the auth handlers from preview.js
+SuccessBehavior.parameters = {
+  msw: {
+      profile: rest.get('/profile', (req, res, ctx) => {
+          return res(
+              ctx.json({
+                  firstName: 'Neil',
+                  lastName: 'Maverick',
+              })
+          )
+      }),
+  }
+}
+
+// story will overwrite the auth handlers from preview.js
+FailureBehavior.parameters = {
+    msw: {
+        auth: rest.get('/login', (req, res, ctx) => {
+            return res(ctx.status(403))
+        }),
+    }
+}
+
+// story will disable the auth handlers from preview.js
+NoAuthBehavior.parameters = {
+    msw: {
+        auth: null,
+        others: [
+            rest.get('/numbers', (req, res, ctx) => {
+                return res(ctx.json([1, 2, 3]))
+            }),
+            rest.get('/strings', (req, res, ctx) => {
+                return res(ctx.json(['a', 'b', 'c']))
+            }),
+        ],
+    }
+}
+```

--- a/packages/msw-addon/src/mswDecorator.js
+++ b/packages/msw-addon/src/mswDecorator.js
@@ -35,17 +35,22 @@ export function getWorker() {
   return api
 }
 
-export const mswDecorator = (storyFn, { parameters: { msw = [] } }) => {
+export const mswDecorator = (storyFn, { parameters: { msw } }) => {
   if (api) {
     api.resetHandlers()
 
-    if (!Array.isArray(msw)) {
-      throw new Error(`[MSW] expected to receive an array of handlers but received "${typeof msw}" instead.
-        Please refer to the documentation: https://mswjs.io/docs/getting-started/mocks/`)
-    }
+    if (msw) {
+      if (Array.isArray(msw) && msw.length > 0) {
+        // support Array of handlers
+        api.use(...msw);
+      } else {
+        // support object of named arrays
+        const handlers = Object.values(msw).filter(Boolean).reduce((acc, arr) => acc.concat(arr), []);
 
-    if (msw.length > 0) {
-      api.use(...msw)
+        if (handlers.length > 0) {
+          api.use(...handlers)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
**This is backwards-compatible change.**

Due to the way storybook merges parameters, if you define msw handlers in preview.js, and then define msw handlers in a story, the ones in preview.js are overwritten.

To solve this, the msw parameter now also accepts an object with named handlers or named arrays of handlers, and then reduces them into a single array of handlers.

I updated the README.md describing how to use the new functionality, however I did not update the docs themselves. I figured you would want to update the documentation with your own examples.