### PR TITLE
Update addon usage in examples and add deprecation message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ $ yarn start
 
 # to start Storybook only (examples/docs)
 # you can instead run `yarn storybook` under packages/docs if you prefer
-$ yarn sb:start
+$ yarn storybook
 
 # to build msw-addon in watch mode only
 # you can instead run `yarn dev` under packages/msw-addon if you prefer

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "packages/*"
   ],
   "scripts": {
-    "sb:start": "yarn workspace msw-storybook-docs storybook",
+    "storybook": "yarn workspace msw-storybook-docs storybook",
     "msw:dev": "yarn workspace msw-storybook-addon dev",
     "start": "npm-run-all --parallel storybook msw:dev",
     "build": "yarn workspace msw-storybook-addon build && yarn workspace msw-storybook-docs build-storybook"

--- a/packages/docs/src/demos/apollo/App.stories.js
+++ b/packages/docs/src/demos/apollo/App.stories.js
@@ -60,31 +60,35 @@ const films = [
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    graphql.query('AllFilmsQuery', (req, res, ctx) => {
-      return res(
-        ctx.data({
-          allFilms: {
-            films,
-          },
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      graphql.query('AllFilmsQuery', (req, res, ctx) => {
+        return res(
+          ctx.data({
+            allFilms: {
+              films,
+            },
+          }),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedError = MockTemplate.bind({});
 MockedError.parameters = {
-  msw: [
-    graphql.query('AllFilmsQuery', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.errors([
-          {
-            message: 'Access denied',
-          },
-        ]),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      graphql.query('AllFilmsQuery', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.errors([
+            {
+              message: 'Access denied',
+            },
+          ]),
+        );
+      }),
+    ]
+  },
 };

--- a/packages/docs/src/demos/apollo/App.test.js
+++ b/packages/docs/src/demos/apollo/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories'
 const server = getServer()
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.parameters.msw)
+  server.use(...MockedSuccess.parameters.msw.handlers)
   render(<MockedSuccess />)
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument()
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 })
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.parameters.msw)
+  server.use(...MockedError.parameters.msw.handlers)
   render(<MockedError />)
 
   const errorMsgNode = await screen.findByText(

--- a/packages/docs/src/demos/axios/App.stories.js
+++ b/packages/docs/src/demos/axios/App.stories.js
@@ -31,25 +31,29 @@ const films = [
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          results: films,
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            results: films,
+          }),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedError = MockTemplate.bind({});
 MockedError.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.status(403),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.status(403),
+        );
+      }),
+    ]
+  },
 };

--- a/packages/docs/src/demos/axios/App.test.js
+++ b/packages/docs/src/demos/axios/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories'
 const server = getServer()
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.parameters.msw)
+  server.use(...MockedSuccess.parameters.msw.handlers)
   render(<MockedSuccess />)
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument()
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 })
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.parameters.msw)
+  server.use(...MockedError.parameters.msw.handlers)
   render(<MockedError />)
 
   const errorMsgNode = await screen.findByText(

--- a/packages/docs/src/demos/fetch/App.stories.js
+++ b/packages/docs/src/demos/fetch/App.stories.js
@@ -31,25 +31,29 @@ const films = [
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          results: films,
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            results: films,
+          }),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedError = MockTemplate.bind({});
 MockedError.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.status(403),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.status(403),
+        );
+      }),
+    ]
+  },
 };

--- a/packages/docs/src/demos/fetch/App.test.js
+++ b/packages/docs/src/demos/fetch/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories'
 const server = getServer()
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.parameters.msw)
+  server.use(...MockedSuccess.parameters.msw.handlers)
   render(<MockedSuccess />)
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument()
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 })
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.parameters.msw)
+  server.use(...MockedError.parameters.msw.handlers)
   render(<MockedError />)
 
   const errorMsgNode = await screen.findByText(

--- a/packages/docs/src/demos/react-query/App.stories.js
+++ b/packages/docs/src/demos/react-query/App.stories.js
@@ -50,25 +50,29 @@ const films = [
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          results: films,
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            results: films,
+          }),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedError = MockTemplate.bind({});
 MockedError.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.status(403),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.status(403),
+        );
+      }),
+    ]
+  },
 };

--- a/packages/docs/src/demos/react-query/App.test.js
+++ b/packages/docs/src/demos/react-query/App.test.js
@@ -11,7 +11,7 @@ afterAll(() => {
 })
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.parameters.msw)
+  server.use(...MockedSuccess.parameters.msw.handlers)
   render(<MockedSuccess />)
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument()
@@ -31,7 +31,7 @@ it('renders error message if it cannot load the films', async () => {
   // get rid of the console.error for this test which adds clutter to the logs
   jest.spyOn(console, 'error').mockImplementationOnce(() => {})
 
-  server.use(...MockedError.parameters.msw)
+  server.use(...MockedError.parameters.msw.handlers)
   render(<MockedError />)
 
   const errorMsgNode = await screen.findByText(

--- a/packages/docs/src/demos/react-router-react-query/App.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/App.stories.js
@@ -1,15 +1,15 @@
-import React from 'react';
-import { MemoryRouter as Router } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from 'react-query';
-import { rest } from 'msw';
-import { App } from './App';
+import React from 'react'
+import { MemoryRouter as Router } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { rest } from 'msw'
+import { App } from './App'
 
 export default {
   title: 'Demos/React Router + RQ',
   component: App,
-};
+}
 
-const defaultQueryClient = new QueryClient();
+const defaultQueryClient = new QueryClient()
 
 export const DefaultApp = () => (
   <QueryClientProvider client={defaultQueryClient}>
@@ -17,7 +17,7 @@ export const DefaultApp = () => (
       <App />
     </Router>
   </QueryClientProvider>
-);
+)
 
 const mockedQueryClient = new QueryClient({
   defaultOptions: {
@@ -25,7 +25,7 @@ const mockedQueryClient = new QueryClient({
       retry: false,
     },
   },
-});
+})
 
 export const MockedApp = () => (
   <QueryClientProvider client={mockedQueryClient}>
@@ -33,102 +33,114 @@ export const MockedApp = () => (
       <App />
     </Router>
   </QueryClientProvider>
-);
+)
 MockedApp.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          results: [
-            {
+  msw: {
+    handlers: {
+      films: [
+        rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+          return res(
+            ctx.json({
+              results: [
+                {
+                  title: '(Mocked) A New Hope',
+                  episode_id: 4,
+                  release_date: '1977-05-25',
+                  url: 'http://swapi.dev/api/films/1/',
+                },
+                {
+                  title: '(Mocked) Empire Strikes Back',
+                  episode_id: 5,
+                  release_date: '1980-05-17',
+                  url: 'http://swapi.dev/api/films/2/',
+                },
+              ],
+            })
+          )
+        }),
+        rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+          return res(
+            ctx.json({
               title: '(Mocked) A New Hope',
               episode_id: 4,
-              release_date: '1977-05-25',
-              url: 'http://swapi.dev/api/films/1/',
-            },
-            {
+              opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
+              characters: [
+                'http://swapi.dev/api/people/1/',
+                'http://swapi.dev/api/people/2/',
+              ],
+            })
+          )
+        }),
+        rest.get('https://swapi.dev/api/films/2', (req, res, ctx) => {
+          return res(
+            ctx.json({
               title: '(Mocked) Empire Strikes Back',
               episode_id: 5,
-              release_date: '1980-05-17',
-              url: 'http://swapi.dev/api/films/2/',
-            },
-          ],
+              opening_crawl: `Imperial troops are pursuing the Rebel forces across the galaxy.`,
+              characters: ['http://swapi.dev/api/people/1/'],
+            })
+          )
         }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          title: '(Mocked) A New Hope',
-          episode_id: 4,
-          opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
-          characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
+      ],
+      people: [
+        rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
+          return res(
+            ctx.json({
+              results: [
+                {
+                  name: '(Mocked) Luke Skywalker',
+                  url: 'http://swapi.dev/api/people/1/',
+                },
+                {
+                  name: '(Mocked) C-3PO',
+                  url: 'http://swapi.dev/api/people/2/',
+                },
+              ],
+            })
+          )
         }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/films/2', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          title: '(Mocked) Empire Strikes Back',
-          episode_id: 5,
-          opening_crawl: `Imperial troops are pursuing the Rebel forces across the galaxy.`,
-          characters: ['http://swapi.dev/api/people/1/'],
-        }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          results: [
-            {
+        rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+          return res(
+            ctx.json({
               name: '(Mocked) Luke Skywalker',
-              url: 'http://swapi.dev/api/people/1/',
-            },
-            {
+              birth_year: '19BBY',
+              eye_color: 'blue',
+              hair_color: 'blond',
+              height: '172',
+              mass: '77',
+              homeworld: 'http://swapi.dev/api/planets/1/',
+              films: [
+                'http://swapi.dev/api/films/1/',
+                'http://swapi.dev/api/films/2/',
+              ],
+            })
+          )
+        }),
+        rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
+          return res(
+            ctx.json({
               name: '(Mocked) C-3PO',
-              url: 'http://swapi.dev/api/people/2/',
-            },
-          ],
+              birth_year: '112BBY',
+              eye_color: 'yellow',
+              hair_color: 'n/a',
+              height: '167',
+              mass: '75',
+              homeworld: 'http://swapi.dev/api/planets/1/',
+              films: ['http://swapi.dev/api/films/1/'],
+            })
+          )
         }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) Luke Skywalker',
-          birth_year: '19BBY',
-          eye_color: 'blue',
-          hair_color: 'blond',
-          height: '172',
-          mass: '77',
-          homeworld: 'http://swapi.dev/api/planets/1/',
-          films: ['http://swapi.dev/api/films/1/', 'http://swapi.dev/api/films/2/'],
-        }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) C-3PO',
-          birth_year: '112BBY',
-          eye_color: 'yellow',
-          hair_color: 'n/a',
-          height: '167',
-          mass: '75',
-          homeworld: 'http://swapi.dev/api/planets/1/',
-          films: ['http://swapi.dev/api/films/1/'],
-        }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) Tatooine',
-        }),
-      );
-    }),
-  ],
-};
+      ],
+      planets: rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            name: '(Mocked) Tatooine',
+          })
+        )
+      }),
+    },
+  },
+}
 
 export const MockedFilmSubsection = () => (
   <QueryClientProvider client={mockedQueryClient}>
@@ -136,46 +148,54 @@ export const MockedFilmSubsection = () => (
       <App />
     </Router>
   </QueryClientProvider>
-);
+)
 MockedFilmSubsection.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          title: '(Mocked) A New Hope',
-          episode_id: 4,
-          opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
-          characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
-        }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) Luke Skywalker',
-          birth_year: '19BBY',
-          eye_color: 'blue',
-          hair_color: 'blond',
-          height: '172',
-          mass: '77',
-          homeworld: 'http://swapi.dev/api/planets/1/',
-          films: ['http://swapi.dev/api/films/1/', 'http://swapi.dev/api/films/2/'],
-        }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) C-3PO',
-          birth_year: '112BBY',
-          eye_color: 'yellow',
-          hair_color: 'n/a',
-          height: '167',
-          mass: '75',
-          homeworld: 'http://swapi.dev/api/planets/1/',
-          films: ['http://swapi.dev/api/films/1/'],
-        }),
-      );
-    }),
-  ],
-};
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            title: '(Mocked) A New Hope',
+            episode_id: 4,
+            opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
+            characters: [
+              'http://swapi.dev/api/people/1/',
+              'http://swapi.dev/api/people/2/',
+            ],
+          })
+        )
+      }),
+      rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            name: '(Mocked) Luke Skywalker',
+            birth_year: '19BBY',
+            eye_color: 'blue',
+            hair_color: 'blond',
+            height: '172',
+            mass: '77',
+            homeworld: 'http://swapi.dev/api/planets/1/',
+            films: [
+              'http://swapi.dev/api/films/1/',
+              'http://swapi.dev/api/films/2/',
+            ],
+          })
+        )
+      }),
+      rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            name: '(Mocked) C-3PO',
+            birth_year: '112BBY',
+            eye_color: 'yellow',
+            hair_color: 'n/a',
+            height: '167',
+            mass: '75',
+            homeworld: 'http://swapi.dev/api/planets/1/',
+            films: ['http://swapi.dev/api/films/1/'],
+          })
+        )
+      }),
+    ]
+  },
+}

--- a/packages/docs/src/demos/react-router-react-query/pages/character/Character.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/pages/character/Character.stories.js
@@ -7,6 +7,44 @@ import Character from './Character';
 export default {
   title: 'Demos/React Router + RQ/Page Stories/Character',
   component: Character,
+  parameters: {
+    msw: {
+      handlers: {
+        common: [
+          rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+            return res(
+              ctx.json({
+                name: '(Mocked) Luke Skywalker',
+                birth_year: '19BBY',
+                eye_color: 'blue',
+                hair_color: 'blond',
+                height: '172',
+                mass: '77',
+                homeworld: 'http://swapi.dev/api/planets/1/',
+                films: ['http://swapi.dev/api/films/1/', 'http://swapi.dev/api/films/2/'],
+              }),
+            );
+          }),
+          rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+            return res(
+              ctx.json({
+                title: '(Mocked) A New Hope',
+                episode_id: 4,
+              }),
+            );
+          }),
+          rest.get('https://swapi.dev/api/films/2', (req, res, ctx) => {
+            return res(
+              ctx.json({
+                title: '(Mocked) Empire Strikes Back',
+                episode_id: 5,
+              }),
+            );
+          }),
+        ]
+      }
+    }
+  }
 };
 
 const defaultQueryClient = new QueryClient();
@@ -20,6 +58,13 @@ export const DefaultBehavior = () => (
     </Router>
   </QueryClientProvider>
 );
+DefaultBehavior.parameters = {
+  msw: {
+    handlers: {
+      common: null
+    }
+  }
+}
 
 const mockedQueryClient = new QueryClient({
   defaultOptions: {
@@ -28,39 +73,6 @@ const mockedQueryClient = new QueryClient({
     },
   },
 });
-
-const commonMockHandlers = [
-  rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-    return res(
-      ctx.json({
-        name: '(Mocked) Luke Skywalker',
-        birth_year: '19BBY',
-        eye_color: 'blue',
-        hair_color: 'blond',
-        height: '172',
-        mass: '77',
-        homeworld: 'http://swapi.dev/api/planets/1/',
-        films: ['http://swapi.dev/api/films/1/', 'http://swapi.dev/api/films/2/'],
-      }),
-    );
-  }),
-  rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-    return res(
-      ctx.json({
-        title: '(Mocked) A New Hope',
-        episode_id: 4,
-      }),
-    );
-  }),
-  rest.get('https://swapi.dev/api/films/2', (req, res, ctx) => {
-    return res(
-      ctx.json({
-        title: '(Mocked) Empire Strikes Back',
-        episode_id: 5,
-      }),
-    );
-  }),
-];
 
 const MockTemplate = () => (
   <QueryClientProvider client={mockedQueryClient}>
@@ -74,24 +86,30 @@ const MockTemplate = () => (
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    ...commonMockHandlers,
-    rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) Tatooine',
+  msw: {
+    handlers: {
+      planets: [
+        rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
+          return res(
+            ctx.json({
+              name: '(Mocked) Tatooine',
+            }),
+          );
         }),
-      );
-    }),
-  ],
+      ]
+    }
+  },
 };
 
 export const MockedPlanetsApiError = MockTemplate.bind({});
 MockedPlanetsApiError.parameters = {
-  msw: [
-    ...commonMockHandlers,
-    rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
-      return res(ctx.delay(800), ctx.status(403));
-    }),
-  ],
+  msw: {
+    handlers: {
+      planets: [
+        rest.get('https://swapi.dev/api/planets/1', (req, res, ctx) => {
+          return res(ctx.delay(800), ctx.status(403));
+        }),
+      ]
+    }
+  },
 };

--- a/packages/docs/src/demos/react-router-react-query/pages/characters/Characters.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/pages/characters/Characters.stories.js
@@ -41,34 +41,38 @@ const MockTemplate = () => (
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          results: [
-            {
-              name: '(Mocked) Luke Skywalker',
-              url: 'http://swapi.dev/api/people/1/',
-            },
-            {
-              name: '(Mocked) C-3PO',
-              url: 'http://swapi.dev/api/people/2/',
-            },
-          ],
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            results: [
+              {
+                name: '(Mocked) Luke Skywalker',
+                url: 'http://swapi.dev/api/people/1/',
+              },
+              {
+                name: '(Mocked) C-3PO',
+                url: 'http://swapi.dev/api/people/2/',
+              },
+            ],
+          }),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedError = MockTemplate.bind({});
 MockedError.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.status(403),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/people/', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.status(403),
+        );
+      }),
+    ]
+  },
 };

--- a/packages/docs/src/demos/react-router-react-query/pages/film/Film.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/pages/film/Film.stories.js
@@ -41,71 +41,77 @@ const MockTemplate = () => (
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          title: '(Mocked) A New Hope',
-          episode_id: 4,
-          opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
-          characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
-        }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) Luke Skywalker',
-        }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) C-3PO',
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            title: '(Mocked) A New Hope',
+            episode_id: 4,
+            opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
+            characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
+          }),
+        );
+      }),
+      rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            name: '(Mocked) Luke Skywalker',
+          }),
+        );
+      }),
+      rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            name: '(Mocked) C-3PO',
+          }),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedFilmApiError = MockTemplate.bind({});
 MockedFilmApiError.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.status(403),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.status(403),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedCharacterApiError = MockTemplate.bind({});
 MockedCharacterApiError.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          title: '(Mocked) A New Hope',
-          episode_id: 4,
-          opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
-          characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
-        }),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.status(403),
-      );
-    }),
-    rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          name: '(Mocked) C-3PO',
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/1', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            title: '(Mocked) A New Hope',
+            episode_id: 4,
+            opening_crawl: `Rebel spaceships have won their first victory against the evil Galactic Empire.`,
+            characters: ['http://swapi.dev/api/people/1/', 'http://swapi.dev/api/people/2/'],
+          }),
+        );
+      }),
+      rest.get('https://swapi.dev/api/people/1', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.status(403),
+        );
+      }),
+      rest.get('https://swapi.dev/api/people/2', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            name: '(Mocked) C-3PO',
+          }),
+        );
+      }),
+    ]
+  },
 };

--- a/packages/docs/src/demos/react-router-react-query/pages/films/Films.stories.js
+++ b/packages/docs/src/demos/react-router-react-query/pages/films/Films.stories.js
@@ -41,38 +41,42 @@ const MockTemplate = () => (
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          results: [
-            {
-              title: '(Mocked) A New Hope',
-              episode_id: 4,
-              release_date: '1977-05-25',
-              url: 'http://swapi.dev/api/films/1/',
-            },
-            {
-              title: '(Mocked) Empire Strikes Back',
-              episode_id: 5,
-              release_date: '1980-05-17',
-              url: 'http://swapi.dev/api/films/2/',
-            },
-          ],
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            results: [
+              {
+                title: '(Mocked) A New Hope',
+                episode_id: 4,
+                release_date: '1977-05-25',
+                url: 'http://swapi.dev/api/films/1/',
+              },
+              {
+                title: '(Mocked) Empire Strikes Back',
+                episode_id: 5,
+                release_date: '1980-05-17',
+                url: 'http://swapi.dev/api/films/2/',
+              },
+            ],
+          }),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedError = MockTemplate.bind({});
 MockedError.parameters = {
-  msw: [
-    rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.status(403),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.status(403),
+        );
+      }),
+    ]
+  },
 };

--- a/packages/docs/src/demos/urql/App.stories.js
+++ b/packages/docs/src/demos/urql/App.stories.js
@@ -49,31 +49,35 @@ const films = [
 
 export const MockedSuccess = MockTemplate.bind({});
 MockedSuccess.parameters = {
-  msw: [
-    graphql.query('AllFilmsQuery', (req, res, ctx) => {
-      return res(
-        ctx.data({
-          allFilms: {
-            films,
-          },
-        }),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      graphql.query('AllFilmsQuery', (req, res, ctx) => {
+        return res(
+          ctx.data({
+            allFilms: {
+              films,
+            },
+          }),
+        );
+      }),
+    ]
+  },
 };
 
 export const MockedError = MockTemplate.bind({});
 MockedError.parameters = {
-  msw: [
-    graphql.query('AllFilmsQuery', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.errors([
-          {
-            message: 'Access denied',
-          },
-        ]),
-      );
-    }),
-  ],
+  msw: {
+    handlers: [
+      graphql.query('AllFilmsQuery', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.errors([
+            {
+              message: 'Access denied',
+            },
+          ]),
+        );
+      }),
+    ]
+  },
 };

--- a/packages/docs/src/demos/urql/App.test.js
+++ b/packages/docs/src/demos/urql/App.test.js
@@ -7,7 +7,7 @@ import { MockedSuccess, MockedError } from './App.stories'
 const server = getServer()
 
 it('renders film cards for each film', async () => {
-  server.use(...MockedSuccess.parameters.msw)
+  server.use(...MockedSuccess.parameters.msw.handlers)
   render(<MockedSuccess />)
 
   expect(screen.getByText(/fetching star wars data/i)).toBeInTheDocument()
@@ -24,7 +24,7 @@ it('renders film cards for each film', async () => {
 })
 
 it('renders error message if it cannot load the films', async () => {
-  server.use(...MockedError.parameters.msw)
+  server.use(...MockedError.parameters.msw.handlers)
   render(<MockedError />)
 
   const errorMsgNode = await screen.findByText(

--- a/packages/msw-addon/src/mswDecorator.js
+++ b/packages/msw-addon/src/mswDecorator.js
@@ -5,7 +5,7 @@ let api
 
 export function initializeWorker(options) {
   console.warn(
-    `[MSW] "initializeWorker" is now deprecated, please use "initialize" instead. This method will be removed in future releases.`
+    `[MSW] "initializeWorker" deprecated, please use "initialize" instead. This method will be removed in future releases.`
   )
   return initialize(options)
 }
@@ -52,6 +52,10 @@ export const mswDecorator = (storyFn, { parameters: { msw } }) => {
       if (Array.isArray(msw) && msw.length > 0) {
         // support Array of handlers (backwards compatability)
         api.use(...msw);
+
+        console.warn(
+          `[MSW] setting handlers directly in the "msw" parameter is deprecated, please use "msw.handlers" instead: https://github.com/mswjs/msw-storybook-addon#usage`
+        )
       } else if (msw.handlers) {
         // support an array named handlers
         // or an Object named handlers with named arrays of handlers


### PR DESCRIPTION
This PR does:

- Update all examples to use the new api. I quite like it
- Fix the storybook command in root package. I forgot to update the script name in the other PR
- Add a deprecation message when users set handlers directly to the `msw` parameter