### PR TITLE
chore: replace logo image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://msw-sb.vercel.app/logo.png" width="200">
+  <img src="https://user-images.githubusercontent.com/1671563/144888802-84346d8f-77c9-4377-98c7-4b0364797978.png" width="200">
 </p>
 <h1 align="center">MSW Storybook Addon</h1>
 

--- a/packages/docs/.storybook/manager-head.html
+++ b/packages/docs/.storybook/manager-head.html
@@ -11,14 +11,14 @@
   property="og:description"
   content="Storybook addon to mock API requests with MSW"
 />
-<meta property="og:image" content="https://msw-sb.vercel.app/logo.png" />
+<meta property="og:image" content="https://user-images.githubusercontent.com/1671563/144888802-84346d8f-77c9-4377-98c7-4b0364797978.png" />
 <meta property="og:site_name" content="Documentation" />
 <meta property="og:url" content="https://msw-sb.vercel.app/" />
 
 <meta name="twitter:card" content="summary_large_image" />
 <meta
   property="twitter:image:src"
-  content="https://msw-sb.vercel.app/logo.png"
+  content="https://user-images.githubusercontent.com/1671563/144888802-84346d8f-77c9-4377-98c7-4b0364797978.png"
 />
 <meta name="twitter:site" content="@dev__adi" />
 <meta name="twitter:creator" content="@dev__adi" />

--- a/packages/docs/src/guides/introduction.stories.mdx
+++ b/packages/docs/src/guides/introduction.stories.mdx
@@ -4,7 +4,7 @@ import LinkTo from '@storybook/addon-links/react'
 <Meta title="Guides/Introduction" />
 
 <header className="introduction-header">
-  <img src="https://msw-sb.vercel.app/logo.png" width="200" height="172" />
+  <img src="https://user-images.githubusercontent.com/1671563/144888802-84346d8f-77c9-4377-98c7-4b0364797978.png" width="200" height="172" />
   <h1>MSW Storybook Addon</h1>
 </header>
 

--- a/packages/msw-addon/package.json
+++ b/packages/msw-addon/package.json
@@ -44,6 +44,6 @@
   },
   "storybook": {
     "displayName": "Mock Service Worker",
-    "icon": "https://msw-sb.vercel.app/logo.png"
+    "icon": "https://user-images.githubusercontent.com/1671563/144888802-84346d8f-77c9-4377-98c7-4b0364797978.png"
   }
 }


### PR DESCRIPTION
Image links were broken after we switched from netlify to vercel, and I feel like we can just leverage the hosting platform of Github instead, so that we don't worry about stuff like this happening again :D