### PR TITLE
chore: fix "msw" peer dependency to 0.35.0 || 0.36.0

### DIFF
--- a/packages/msw-addon/package.json
+++ b/packages/msw-addon/package.json
@@ -40,7 +40,7 @@
     "typescript": "^4.5.2"
   },
   "peerDependencies": {
-    "msw": "^0.35.0"
+    "msw": "^0.35.0 || ^0.36.0"
   },
   "storybook": {
     "displayName": "Mock Service Worker",


### PR DESCRIPTION
This PR fixes peerDependencies to use current msw's version `v0.36.4`. 
https://github.com/mswjs/msw/releases