### PR TITLE
dep: expand msw peer dependency version range

### DIFF
--- a/packages/msw-addon/package.json
+++ b/packages/msw-addon/package.json
@@ -40,7 +40,7 @@
     "typescript": "^4.5.2"
   },
   "peerDependencies": {
-    "msw": "^0.35.0 || ^0.36.0"
+    "msw": "^0.35"
   },
   "storybook": {
     "displayName": "Mock Service Worker",


### PR DESCRIPTION
Issue: #74

This PR proposes the following approach:
Set MSW as a peer dependency from 0.35 and higher minor versions.

The idea is that MSW is a peer dependency and will be managed by the users, which might want to try out new features and will always end up hitting a roadblock with this addon. In case MSW does release a breaking change as a minor, we will have to deal with it in the addon, which might be a good thing because it will force a faster evolution/sync of the addon

Thoughts @kettanaito ?