### PR TITLE
do not reset handlers if msw is not defined for story, fix #25

### DIFF
--- a/packages/msw-addon/src/mswDecorator.ts
+++ b/packages/msw-addon/src/mswDecorator.ts
@@ -79,26 +79,24 @@ export const mswDecorator: DecoratorFunction = (
     parameters: { msw },
   } = context
 
-  if (api) {
+  if (api && msw) {
     api.resetHandlers()
 
-    if (msw) {
-      if (Array.isArray(msw) && msw.length > 0) {
-        // Support an Array of request handlers (backwards compatability).
-        api.use(...msw)
-      } else if ('handlers' in msw && msw.handlers) {
-        // Support an Array named request handlers handlers
-        // or an Object of named request handlers with named arrays of handlers
-        const handlers = Object.values(msw.handlers)
-          .filter(Boolean)
-          .reduce(
-            (handlers, handlersList) => handlers.concat(handlersList),
-            [] as RequestHandler[]
-          )
+    if (Array.isArray(msw) && msw.length > 0) {
+      // Support an Array of request handlers (backwards compatability).
+      api.use(...msw)
+    } else if ('handlers' in msw && msw.handlers) {
+      // Support an Array named request handlers handlers
+      // or an Object of named request handlers with named arrays of handlers
+      const handlers = Object.values(msw.handlers)
+        .filter(Boolean)
+        .reduce(
+          (handlers, handlersList) => handlers.concat(handlersList),
+          [] as RequestHandler[]
+        )
 
-        if (handlers.length > 0) {
-          api.use(...handlers)
-        }
+      if (handlers.length > 0) {
+        api.use(...handlers)
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/mswjs/msw-storybook-addon/issues/25

Ensuring that api.resetHandlers() is only called if msw is defined as a parameter of a story solves the issue where if any loaded story file didn't have an msw parameter defined the browser window would hang.

While this solves the issue in my storybook, I am not sure if it can have any unintended effects, please let me know!