### PR TITLE
Wait in loader for MSW to be fully ready

### DIFF
--- a/packages/msw-addon/src/mswDecorator.ts
+++ b/packages/msw-addon/src/mswDecorator.ts
@@ -28,12 +28,13 @@ export interface LoaderContext extends StoryContext {
 
 const IS_BROWSER = !isNodeProcess()
 let api: SetupApi
+let workerPromise: Promise<unknown>;
 
 export function initialize(options?: InitializeOptions): SetupApi {
   if (IS_BROWSER) {
     const { setupWorker } = require('msw')
     const worker = setupWorker()
-    worker.start(options)
+    workerPromise = worker.start(options)
     api = worker
   } else {
     /**
@@ -50,7 +51,7 @@ export function initialize(options?: InitializeOptions): SetupApi {
 
     const { setupServer } = __non_webpack_require__('msw/node')
     const server = setupServer()
-    server.listen(options)
+    workerPromise = server.listen(options)
     api = server
   }
 
@@ -137,6 +138,8 @@ export const mswLoader: LoaderFunction = async (context: LoaderContext) => {
       }
     }
   }
+
+  await (workerPromise || Promise.resolve());
 
   return {}
 }


### PR DESCRIPTION
I really wanted to use MSW to reduce flakiness around placeholder images that would show up in chromatic snapshot tests. I suspected that a loader would help, and saw this PR, but in my testing the only way to ensure that requests for static assets that are sent on mount are properly mocked is to wait for the service worker startup to complete by waiting on this promise returned from `worker.start`.