### PR TITLE
ci(release): use node-version 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16.14.0
+          node-version: 16
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
instead of 16.14. For consistency with other workflows using node.

Relates to https://github.com/mswjs/msw/issues/1304