### PR TITLE
chore: Upgrade `cycjimmy/semantic-release-action` to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn test
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
There have been recent releases of `semantic-release` which broke the default behavior of `cycjimmy/semantic-release-action@v2`:

```
Must use import to load ES Module: /home/runner/work/_actions/cycjimmy/semantic-release-action/v2/node_modules/semantic-release/index.js
require() of ES modules is not supported.
```

They get fixed either by upgrading the action or specifying semantic-release version to be 19.