### PR TITLE
Feature: Support React Native environments

### DIFF
--- a/packages/docs/src/demos/fetch/App.jsx
+++ b/packages/docs/src/demos/fetch/App.jsx
@@ -18,7 +18,6 @@ function useFetchFilms() {
       })
       .then((res) => res.json())
       .then((data) => {
-        console.log({ data })
         setStatus('success');
         setData(data.results);
       })
@@ -36,7 +35,6 @@ function useFetchFilms() {
 export function App() {
   const { status, data: films } = useFetchFilms();
 
-  console.log({ status, films })
   if (status === 'loading') {
     return <p>Fetching Star Wars data...</p>;
   }

--- a/packages/docs/src/demos/fetch/App.stories.jsx
+++ b/packages/docs/src/demos/fetch/App.stories.jsx
@@ -31,7 +31,6 @@ export const MockedSuccess = {
     msw: {
       handlers: [
         rest.get('https://swapi.dev/api/films/', (req, res, ctx) => {
-          console.log('MATCHED!')
           return res(
             ctx.json({
               results: films,

--- a/packages/msw-addon/src/mswDecorator.ts
+++ b/packages/msw-addon/src/mswDecorator.ts
@@ -20,11 +20,17 @@ type Context = {
 }
 
 const IS_BROWSER = !isNodeProcess()
+const IS_REACT_NATIVE = typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
 let api: SetupApi
 let workerPromise: Promise<unknown>
 
 export function initialize(options?: InitializeOptions): SetupApi {
-  if (IS_BROWSER) {
+  if (IS_REACT_NATIVE) {
+    const { setupServer } = require('msw/native')
+    const server = setupServer()
+    workerPromise = server.listen(options)
+    api = server;
+  } else if (IS_BROWSER) {
     const { setupWorker } = require('msw')
     const worker = setupWorker()
     workerPromise = worker.start(options)


### PR DESCRIPTION
Now that @storybook/react-native has reached compatibility with storybook 6, it supports CSF, which means we can _almost_ use this decorator for react native storybooks!

There's just one missing piece: the `initialize` function needs to call `setupServer` from `msw/native` in a ReactNative environment. Credit to [this post](https://phelipetls.github.io/posts/using-storybook-and-msw-in-react-native/) for that part.

This PR adds a special case for react native next to the existing DOM and Node initialization code.