### PR TITLE
fix(loader.ts): fix possible undefined

### DIFF
--- a/packages/msw-addon/src/loader.ts
+++ b/packages/msw-addon/src/loader.ts
@@ -7,7 +7,7 @@ export const mswLoader = async (context: Context) => {
   if (
     typeof window !== 'undefined' &&
     'navigator' in window &&
-    navigator.serviceWorker.controller
+    navigator.serviceWorker?.controller
   ) {
     // No need to rely on the MSW Promise exactly
     // since only 1 worker can control 1 scope at a time.


### PR DESCRIPTION
If msw is running in fallback mode, navigator.serviceWorker may not be defined.

https://github.com/mswjs/msw-storybook-addon/pull/122