### PR TITLE
Fix `MswParameters` handlers type

### DIFF
--- a/packages/msw-addon/src/decorator.ts
+++ b/packages/msw-addon/src/decorator.ts
@@ -6,7 +6,7 @@ export type MswParameters = {
   msw?:
     | RequestHandler[]
     | {
-        handlers: RequestHandler[] | Record<string, RequestHandler>
+        handlers: RequestHandler[] | Record<string, RequestHandler[]>
       }
 }
 

--- a/packages/msw-addon/src/decorator.ts
+++ b/packages/msw-addon/src/decorator.ts
@@ -6,7 +6,7 @@ export type MswParameters = {
   msw?:
     | RequestHandler[]
     | {
-        handlers: RequestHandler[] | Record<string, RequestHandler[]>
+        handlers: RequestHandler[] | Record<string, RequestHandler | RequestHandler[]>
       }
 }
 


### PR DESCRIPTION
The type does not seem to match the docs which say:
```typescript
type MswParameter = {
  handlers: RequestHandler[] | Record<string, RequestHandler | RequestHandler[]>
}
```
[ref](https://storybook.js.org/addons/msw-storybook-addon#composing-request-handlers)