### PR TITLE
refactor: change MswParameters and Context from type to interface in decorator.ts

### DIFF
--- a/packages/msw-addon/src/decorator.ts
+++ b/packages/msw-addon/src/decorator.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from 'msw'
 import { applyRequestHandlers } from './applyRequestHandlers.js'
 import { deprecate } from './util.js'
 
-export type MswParameters = {
+export interface MswParameters {
   msw?:
     | RequestHandler[]
     | {
@@ -10,7 +10,7 @@ export type MswParameters = {
       }
 }
 
-export type Context = {
+export interface Context {
   parameters: MswParameters
 }
 


### PR DESCRIPTION
This is done to support typescript declaration merging.

I have code where I augment the storybook parameters,
This causes an error in the storybook when registering the mswLoader to the storybook loaders, which uses the MSW parameters, as they now do not match.

Changing from type to an interface allows consumers to augment the types.

The consumer could augment the storybook parameters type and the mswParamters type to match.



Example to augment the interfaces in consumer code after the PR's changes:
```typescript
import { mswLoader } from 'msw-storybook-addon';
...

// modifying storybook's params
declare module '@storybook/react' {
  interface Parameters {
    router?: RouterParameters;
  }
}
// modifying addon's params
declare module 'msw-storybook-addon' {
  interface MswParameters {
    router?: RouterParameters;
  }
}

// register the loaders;
// without this PR and only augmenting the storybook Parameters there would be a type error here
const loaders: StorybookLoader[] = [mswLoader];

const preview: Preview = {
  parameters,
  decorators,
  loaders,
};

export default preview;
```
