### PR TITLE
fix: add a `@deprecated` tag to the `mswDecorator`

### DIFF
--- a/packages/msw-addon/src/decorator.ts
+++ b/packages/msw-addon/src/decorator.ts
@@ -23,7 +23,7 @@ More info: https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#m
 
 /**
  * @deprecated The `mswDecorator` is deprecated and will be removed in the next release. Please use the `mswLoader` instead.
- * More info: https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#mswdecorator-is-deprecated-in-favor-of-mswloader
+ * More info: https://github.com/mswjs/msw-storybook-addon/blob/ec35e9371f8a56a27220838fba798b9001ac7fad/MIGRATION.md#mswdecorator-is-deprecated-in-favor-of-mswloader
  */
 export const mswDecorator = <Story extends (...args: any[]) => any>(
   storyFn: Story,

--- a/packages/msw-addon/src/decorator.ts
+++ b/packages/msw-addon/src/decorator.ts
@@ -21,6 +21,10 @@ const deprecateMessage = deprecate(`
 More info: https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#mswdecorator-is-deprecated-in-favor-of-mswloader
 `)
 
+/**
+ * @deprecated The `mswDecorator` is deprecated and will be removed in the next release. Please use the `mswLoader` instead.
+ * More info: https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#mswdecorator-is-deprecated-in-favor-of-mswloader
+ */
 export const mswDecorator = <Story extends (...args: any[]) => any>(
   storyFn: Story,
   context: Context


### PR DESCRIPTION
Previously, this was only communicated to the user via the browser console, and so was easy to miss. I only noticed it because of reading the changelog.

It'll be much more likely for users to notice this deprecation if their editor tells them that it's deprecated, so this will hopefully help ease migration.

<img width="717" height="187" alt="Screenshot 2025-10-02 at 7 20 53 PM" src="https://github.com/user-attachments/assets/d026bf81-40dd-45a8-a986-a52467116317" />
