### PR TITLE
fix: stop relying on `worker.context`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/packages/msw-addon/src/initialize.browser.ts
+++ b/packages/msw-addon/src/initialize.browser.ts
@@ -1,40 +1,38 @@
-import type { RequestHandler } from 'msw'
-import { setupWorker } from 'msw/browser'
-import { augmentInitializeOptions } from './augmentInitializeOptions.js'
+import type { RequestHandler } from "msw";
+import { setupWorker } from "msw/browser";
+import { augmentInitializeOptions } from "./augmentInitializeOptions.js";
 
-type SetupWorker = ReturnType<typeof setupWorker>
+type SetupWorker = ReturnType<typeof setupWorker>;
 
-export let api: SetupWorker
+export let api: SetupWorker;
 
-type ContextfulWorker = SetupWorker & {
-  context: { isMockingEnabled: boolean; activationPromise?: any }
-}
+export type InitializeOptions = Parameters<SetupWorker["start"]>[0];
 
-export type InitializeOptions = Parameters<SetupWorker['start']>[0]
+let activationPromise: Promise<void>;
 
 export function initialize(
   options?: InitializeOptions,
   initialHandlers: RequestHandler[] = []
 ): SetupWorker {
-  const worker = setupWorker(...initialHandlers) as ContextfulWorker
-  worker.context.activationPromise = worker.start(
-    augmentInitializeOptions(options)
-  )
-  api = worker
-  return worker
+  const worker = setupWorker(...initialHandlers);
+  activationPromise = worker
+    .start(augmentInitializeOptions(options))
+    .then(() => {});
+  api = worker;
+  return worker;
 }
 
 export async function waitForMswReady() {
-  const msw = getWorker() as ContextfulWorker
-  await msw.context.activationPromise
+  getWorker();
+  await activationPromise;
 }
 
 export function getWorker(): SetupWorker {
   if (api === undefined) {
     throw new Error(
       `[MSW] Failed to retrieve the worker: no active worker found. Did you forget to call "initialize"?`
-    )
+    );
   }
 
-  return api
+  return api;
 }

--- a/packages/msw-addon/src/initialize.browser.ts
+++ b/packages/msw-addon/src/initialize.browser.ts
@@ -1,38 +1,38 @@
-import type { RequestHandler } from "msw";
-import { setupWorker } from "msw/browser";
-import { augmentInitializeOptions } from "./augmentInitializeOptions.js";
+import type { RequestHandler } from 'msw'
+import { setupWorker } from 'msw/browser'
+import { augmentInitializeOptions } from './augmentInitializeOptions.js'
 
-type SetupWorker = ReturnType<typeof setupWorker>;
+type SetupWorker = ReturnType<typeof setupWorker>
 
-export let api: SetupWorker;
+export let api: SetupWorker
 
-export type InitializeOptions = Parameters<SetupWorker["start"]>[0];
+export type InitializeOptions = Parameters<SetupWorker['start']>[0]
 
-let activationPromise: Promise<void>;
+let activationPromise: Promise<void>
 
 export function initialize(
   options?: InitializeOptions,
   initialHandlers: RequestHandler[] = []
 ): SetupWorker {
-  const worker = setupWorker(...initialHandlers);
+  const worker = setupWorker(...initialHandlers)
   activationPromise = worker
     .start(augmentInitializeOptions(options))
-    .then(() => {});
-  api = worker;
-  return worker;
+    .then(() => {})
+  api = worker
+  return worker
 }
 
 export async function waitForMswReady() {
-  getWorker();
-  await activationPromise;
+  getWorker()
+  await activationPromise
 }
 
 export function getWorker(): SetupWorker {
   if (api === undefined) {
     throw new Error(
       `[MSW] Failed to retrieve the worker: no active worker found. Did you forget to call "initialize"?`
-    );
+    )
   }
 
-  return api;
+  return api
 }


### PR DESCRIPTION
- Fixes #183 