### PR TITLE
fix: support csf 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
     "msw": ">=2",
     "storybook": ">=9"
   },
-  "dependencies": {
-    "is-node-process": "^1.2.0"
-  },
   "msw": {
     "workerDirectory": [
       "tests/public"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "Mock APIs in Storybook using Mock Service Worker.",
   "main": "./build/index.mjs",
   "exports": {
-    ".": "./build/index.mjs"
+    ".": "./build/index.mjs",
+    "./preview": "./build/preview.mjs",
+    "./types": "./build/index.d.mts"
   },
   "storybook": {
     "displayName": "Mock Service Worker"
@@ -50,6 +52,7 @@
     "@types/react": "^19.2.14",
     "@vitest/browser-playwright": "4.1.2",
     "@vitest/coverage-v8": "4.1.2",
+    "@msw/storybook": "link:.",
     "msw": "^2.12.14",
     "publint": "^0.3.18",
     "react": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@msw/storybook':
+        specifier: link:.
+        version: 'link:'
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      is-node-process:
-        specifier: ^1.2.0
-        version: 1.2.0
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1,0 +1,30 @@
+import type { MswApi } from './types'
+import type { ProjectAnnotations, Renderer } from 'storybook/internal/types'
+export type SetupFunction = () => MswApi | Promise<MswApi>
+
+const defaultSetup: SetupFunction = async () => {
+  const { setupWorker } = await import('msw/browser')
+  const worker = setupWorker()
+  await worker.start({ quiet: true })
+  return worker
+}
+
+let mswInstance: MswApi | undefined
+
+export function createPreviewAnnotations(
+  setup: SetupFunction = defaultSetup,
+): ProjectAnnotations<Renderer> {
+  return {
+    async beforeEach(context) {
+      if (mswInstance == null) {
+        mswInstance = await setup()
+      }
+
+      context.msw = mswInstance
+
+      return () => {
+        context.msw?.resetHandlers()
+      }
+    },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,6 @@
-import type { SetupApi, LifeCycleEventsMap } from 'msw'
 import { definePreviewAddon } from 'storybook/internal/csf'
+import { createPreviewAnnotations, type SetupFunction } from './addon'
 
-declare module 'storybook/internal/csf' {
-  interface StoryContext {
-    msw: MswApi
-  }
-}
-
-export type MswApi = Pick<
-  SetupApi<LifeCycleEventsMap>,
-  'use' | 'restoreHandlers' | 'resetHandlers' | 'listHandlers'
->
-
-async function defaultSetup(): Promise<MswApi> {
-  const { setupWorker } = await import('msw/browser')
-  const worker = setupWorker()
-  await worker.start({ quiet: true })
-  return worker
-}
-
-let mswInstance: MswApi | undefined
-
-export default function addonMsw(
-  setup: () => MswApi | Promise<MswApi> = defaultSetup,
-) {
-  return definePreviewAddon({
-    async beforeEach(context) {
-      if (mswInstance == null) {
-        mswInstance = await setup()
-      }
-
-      context.msw = mswInstance
-
-      return () => {
-        context.msw?.resetHandlers()
-      }
-    },
-  })
+export default function addonMsw(setup?: SetupFunction) {
+  return definePreviewAddon(createPreviewAnnotations(setup))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ async function defaultSetup(): Promise<MswApi> {
 
 let mswInstance: MswApi | undefined
 
-export function enableMocking(
+export default function addonMsw(
   setup: () => MswApi | Promise<MswApi> = defaultSetup,
 ) {
   return definePreviewAddon({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { isNodeProcess } from 'is-node-process'
 import type { SetupApi, LifeCycleEventsMap } from 'msw'
 import { definePreviewAddon } from 'storybook/internal/csf'
 
@@ -14,13 +13,6 @@ export type MswApi = Pick<
 >
 
 async function defaultSetup(): Promise<MswApi> {
-  // if (isNodeProcess()) {
-  //   const { setupServer } = await import('msw/node')
-  //   const server = setupServer()
-  //   server.listen()
-  //   return server
-  // }
-
   const { setupWorker } = await import('msw/browser')
   const worker = setupWorker()
   await worker.start({ quiet: true })

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,0 +1,1 @@
+export { createPreviewAnnotations } from './addon'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+export type MswApi = Pick<
+  import('msw').SetupApi<import('msw').LifeCycleEventsMap>,
+  'use' | 'restoreHandlers' | 'resetHandlers' | 'listHandlers'
+>
+
+declare module 'storybook/internal/csf' {
+  interface StoryContext {
+    msw: MswApi
+  }
+}

--- a/tests/base/.storybook/preview.ts
+++ b/tests/base/.storybook/preview.ts
@@ -1,9 +1,9 @@
 import { definePreview } from '@storybook/react-vite'
-import { enableMocking } from '@msw/storybook'
+import addonMsw from '@msw/storybook'
 import { http, HttpResponse } from 'msw'
 
 export default definePreview({
-  addons: [enableMocking()],
+  addons: [addonMsw()],
   beforeEach({ msw }) {
     msw.use(
       http.get('https://api.example.com/user', () => {

--- a/tests/csf-3/.storybook/main.ts
+++ b/tests/csf-3/.storybook/main.ts
@@ -1,0 +1,8 @@
+import { StorybookConfig } from '@storybook/react-vite'
+
+export default {
+  framework: '@storybook/react-vite',
+  stories: ['../stories/**/*.stories.tsx'],
+  addons: ['@msw/storybook', '@storybook/addon-vitest'],
+  staticDirs: ['../../public'],
+} satisfies StorybookConfig

--- a/tests/csf-3/.storybook/preview.ts
+++ b/tests/csf-3/.storybook/preview.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw'
+import type { ProjectAnnotations, Renderer } from 'storybook/internal/types'
+
+export default {
+  beforeEach({ msw }) {
+    msw.use(
+      http.get('https://api.example.com/user', () => {
+        return HttpResponse.json({ name: 'John Maverick' })
+      }),
+    )
+  },
+} satisfies ProjectAnnotations<Renderer>

--- a/tests/csf-3/stories/csf-3.stories.tsx
+++ b/tests/csf-3/stories/csf-3.stories.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react'
+import { http, HttpResponse } from 'msw'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, waitFor } from 'storybook/test'
+
+function UserProfile() {
+  const [user, setUser] = useState<{ name: string } | null>(null)
+
+  useEffect(() => {
+    fetch('https://api.example.com/user')
+      .then((response) => response.json())
+      .then(setUser)
+  }, [])
+
+  if (!user) return <p>Loading...</p>
+
+  return <p>{user.name}</p>
+}
+
+const meta = {
+  title: 'Scenarios',
+  component: UserProfile,
+} satisfies Meta<typeof UserProfile>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const PreviewHandlers: Story = {
+  async play({ canvas }) {
+    await waitFor(async () => {
+      await expect(canvas.getByRole('paragraph')).toHaveTextContent(
+        'John Maverick',
+      )
+    })
+  },
+}
+
+export const StoryOverrides: Story = {
+  name: 'Per-Story Handlers',
+  beforeEach({ msw }) {
+    msw.use(
+      http.get('https://api.example.com/user', () => {
+        return HttpResponse.json({ name: 'Alice Sunwell' })
+      }),
+    )
+  },
+  async play({ canvas }) {
+    await waitFor(async () => {
+      await expect(canvas.getByRole('paragraph')).toHaveTextContent(
+        'Alice Sunwell',
+      )
+    })
+  },
+}

--- a/tests/csf-3/tsconfig.json
+++ b/tests/csf-3/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+  "compilerOptions": {
+    "types": ["@msw/storybook/types"],
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["./src"],
+  "include": ["./src", "types.d.ts"],
   "compilerOptions": {
     "strict": true,
     "skipLibCheck": true,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts'],
+  entry: ['./src/index.ts', './src/preview.ts', './src/types.ts'],
   outDir: './build',
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## Changes

- Addon now exports a default export.
- Adds support for `/preview` usage (CSF 3).
- Adds `@msw/storybook/types` you can use for type-safe `StoryContext` with CSF 3.0.