### PR TITLE
feat: V3 API rework to support CSF3 and factories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /node_modules
+**/node_modules
 /build
+*.tsbuildinfo
+**/dist
 
 # misc
 .DS_Store

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,9 +1,69 @@
 <h1>Migration</h1>
 
+- [From 2.x.x to 3.x.x](#from-2xx-to-3xx)
+  - [Handlers move from `parameters.msw` to `beforeEach({ msw })`](#handlers-move-from-parametersmsw-to-beforeeach-msw-)
+  - [`mswLoader` and `mswDecorator` are removed](#mswloader-and-mswdecorator-are-removed)
+  - [`initialize()` is now only for CSF 3.0 customization](#initialize-is-now-only-for-csf-30-customization)
 - [From 1.x.x to 2.x.x](#from-1xx-to-2xx)
   - [MSW required version is now ^2.0.0](#msw-required-version-is-now-200)
   - [mswDecorator is deprecated in favor of mswLoader](#mswdecorator-is-deprecated-in-favor-of-mswloader)
   - [parameters.msw Array notation deprecated in favor of Object notation](#parametersmsw-array-notation-deprecated-in-favor-of-object-notation)
+
+## From 2.x.x to 3.x.x
+
+3.x reworks how handlers are provided. Instead of declaring handlers as
+`parameters.msw` and registering an `mswLoader`, you now receive a live
+`msw` worker on the story context and call `msw.use(...)` from a
+`beforeEach` hook. This removes the long-standing race where the service
+worker could fail to register before a story rendered: the worker is now
+started and awaited before any story (or its `play` function) runs.
+
+### Handlers move from `parameters.msw` to `beforeEach({ msw })`
+
+```diff
+ export const UserProfile = {
+-  parameters: {
+-    msw: {
+-      handlers: [
+-        http.get('https://api.acme.com/user', () => HttpResponse.json({ name: 'John' })),
+-      ],
+-    },
+-  },
++  beforeEach({ msw }) {
++    msw.use(
++      http.get('https://api.acme.com/user', () => HttpResponse.json({ name: 'John' })),
++    )
++  },
+ }
+```
+
+Global handlers move the same way, from `parameters.msw` in `preview.*` to a
+top-level `beforeEach({ msw })`.
+
+### `mswLoader` and `mswDecorator` are removed
+
+The addon's `beforeEach` now builds and awaits the worker automatically, so
+there is nothing to register. Remove the `mswLoader`/`mswDecorator` import
+and any `loaders: [mswLoader]` / `decorators: [mswDecorator]` entry from
+`.storybook/preview.*`.
+
+### `initialize()` is now only for CSF 3.0 customization
+
+You no longer need to call `initialize()` for the addon to work — it is
+auto-wired. Keep `initialize(options, initialHandlers)` only if you are using
+CSF 3.0 and need custom `start()` options or initial handlers.
+When using [CSF factories](https://storybook.js.org/docs/api/csf/csf-next) path, pass a setup function to `mswAddon(setup)` instead.
+
+`initialize` has also moved to a dedicated subpath so the main entry stays
+free of `msw/browser`. Update the import:
+
+```diff
+-import { initialize } from 'msw-storybook-addon'
++import { initialize } from 'msw-storybook-addon/csf3'
+```
+
+Other exports (`MswApi`, `InitializeOptions`) remain on the main
+`msw-storybook-addon` entry.
 
 ## From 1.x.x to 2.x.x
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,60 @@ export const UserProfileNetworkError: Story = {
 }
 ```
 
+### Customizing the worker
+
+By default the addon starts a bare worker for you. To pass MSW
+[`start()` options](https://mswjs.io/docs/api/setup-worker/start) or
+register initial handlers that survive `resetHandlers()` between stories:
+
+- **CSF factories** — pass a setup function to `addonMsw()`:
+
+  ```ts
+  // .storybook/preview.ts
+  export default definePreview({
+    addons: [
+      addonMsw(async () => {
+        const { setupWorker } = await import('msw/browser')
+        const worker = setupWorker(...defaultHandlers)
+        await worker.start({ onUnhandledRequest: 'bypass' })
+        return worker
+      }),
+    ],
+  })
+  ```
+
+- **CSF 3.0** — call `initialize(options, initialHandlers)` in `preview.ts`:
+
+  ```ts
+  // .storybook/preview.ts
+  import { initialize } from 'msw-storybook-addon/csf3'
+
+  initialize({ onUnhandledRequest: 'bypass' }, [
+    http.get('https://api.acme.com/user', () => HttpResponse.json({ name: 'John' })),
+  ])
+  ```
+
+## Handler precedence
+
+When more than one source registers a handler for the same request, the
+last one to apply wins (MSW resolves the most recently registered handler
+first). From highest to lowest priority:
+
+1. **`parameters.msw`** (deprecated - please migrate away from it) — applied at render, so it overrides everything below it
+2. story-level `beforeEach({ msw })`
+3. component/meta-level `beforeEach({ msw })`
+4. preview-level `beforeEach({ msw })`
+5. initial handlers from `initialize(_, [...])` / `mswAddon(setup)` — the
+   baseline, restored between stories
+
+Do **not** define both `parameters.msw` and `beforeEach({ msw })` for the
+same request: the deprecated `parameters.msw` will silently win regardless
+of where each is declared. Use `beforeEach` instead.
+
+## Migrating from older versions
+
+See [MIGRATION.md](./MIGRATION.md) for details and hand-migration steps.
+
 ## Related materials
 
 - [Mock Service Worker](https://mswjs.io/docs)

--- a/package.json
+++ b/package.json
@@ -4,9 +4,20 @@
   "version": "0.0.0",
   "description": "Mock APIs in Storybook using Mock Service Worker.",
   "exports": {
-    ".": "./build/index.mjs",
-    "./preview": "./build/preview.mjs",
-    "./types": "./build/index.d.mts"
+    ".": {
+      "types": "./build/index.d.mts",
+      "default": "./build/index.mjs"
+    },
+    "./csf3": {
+      "types": "./build/csf3.d.mts",
+      "default": "./build/csf3.mjs"
+    },
+    "./preview": {
+      "types": "./build/preview.d.mts",
+      "default": "./build/preview.mjs"
+    },
+    "./types": "./build/types.d.mts",
+    "./package.json": "./package.json"
   },
   "storybook": {
     "displayName": "Mock Service Worker"
@@ -15,8 +26,10 @@
     "dev": "tsdown --watch",
     "lint": "publint",
     "install:browsers": "pnpm exec playwright install chromium --with-deps",
-    "storybook": "storybook dev --config-dir ./tests/base/.storybook",
+    "storybook": "storybook dev --config-dir ./tests/base/.storybook --port 6006",
+    "storybook:csf-3": "storybook dev --config-dir ./tests/csf-3/.storybook --port 6007",
     "test:stories": "playwright test",
+    "test:stories:csf-3": "playwright test --config=playwright.csf-3.config.ts",
     "test:play": "vitest -c ./tests/base/vitest.config.ts --project storybook",
     "build": "tsdown",
     "release": "release publish"
@@ -50,6 +63,7 @@
     "@playwright/test": "^1.59.1",
     "@storybook/addon-vitest": "^10.3.4",
     "@storybook/react-vite": "^10.3.4",
+    "@types/node": "^22.10.0",
     "@types/react": "^19.2.14",
     "@vitest/browser-playwright": "4.1.2",
     "@vitest/coverage-v8": "4.1.2",

--- a/playwright.csf-3.config.ts
+++ b/playwright.csf-3.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from '@playwright/test'
 
-const PORT = 56789
+// CSF3 suite — separate Storybook instance/port because its preview/main
+// config (addon via `main.ts addons`) is incompatible with the base
+// (factories) setup.
+const PORT = 56790
 
 export default defineConfig({
-  // Base suite only; the CSF3 suite has its own config + Storybook port.
-  testDir: './tests/base',
+  testDir: './tests/csf-3',
   testMatch: '*.test.ts',
   timeout: 5000,
   forbidOnly: !!process.env.CI,
@@ -15,7 +17,7 @@ export default defineConfig({
     serviceWorkers: 'allow',
   },
   webServer: {
-    command: `pnpm storybook -p ${PORT}`,
+    command: `pnpm storybook:csf-3 -p ${PORT}`,
     port: PORT,
     reuseExistingServer: true,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,22 +16,25 @@ importers:
         version: 1.59.1
       '@storybook/addon-vitest':
         specifier: ^10.3.4
-        version: 10.3.4(@vitest/browser-playwright@4.1.2)(@vitest/browser@4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2))(@vitest/runner@4.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.2)
+        version: 10.3.4(@vitest/browser-playwright@4.1.2)(@vitest/browser@4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2))(@vitest/runner@4.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.2)
       '@storybook/react-vite':
         specifier: ^10.3.4
-        version: 10.3.4(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3))
+        version: 10.3.4(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.19))
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.19
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
       '@vitest/browser-playwright':
         specifier: 4.1.2
-        version: 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(playwright@1.59.1)(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2)
+        version: 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(playwright@1.59.1)(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2)
       '@vitest/coverage-v8':
         specifier: 4.1.2
-        version: 4.1.2(@vitest/browser@4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2))(vitest@4.1.2)
+        version: 4.1.2(@vitest/browser@4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2))(vitest@4.1.2)
       msw:
         specifier: ^2.12.14
-        version: 2.12.14(@types/node@25.3.3)(typescript@5.9.3)
+        version: 2.12.14(@types/node@22.19.19)(typescript@5.9.3)
       msw-storybook-addon:
         specifier: link:.
         version: 'link:'
@@ -55,7 +58,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.3.3)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))
+        version: 4.1.2(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))
 
 packages:
 
@@ -476,36 +479,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -576,66 +585,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -804,11 +826,11 @@ packages:
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
-
-  '@types/node@25.3.3':
-    resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -1919,11 +1941,11 @@ packages:
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -2329,37 +2351,37 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/confirm@5.1.21(@types/node@25.3.3)':
+  '@inquirer/confirm@5.1.21(@types/node@22.19.19)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@22.19.19)
+      '@inquirer/type': 3.0.10(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 22.19.19
 
-  '@inquirer/core@10.3.2(@types/node@25.3.3)':
+  '@inquirer/core@10.3.2(@types/node@22.19.19)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/type': 3.0.10(@types/node@22.19.19)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 22.19.19
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/type@3.0.10(@types/node@25.3.3)':
+  '@inquirer/type@3.0.10(@types/node@22.19.19)':
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 22.19.19
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.19))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.3.3)
+      vite: 7.3.1(@types/node@22.19.19)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2595,39 +2617,39 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-vitest@10.3.4(@vitest/browser-playwright@4.1.2)(@vitest/browser@4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2))(@vitest/runner@4.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.2)':
+  '@storybook/addon-vitest@10.3.4(@vitest/browser-playwright@4.1.2)(@vitest/browser@4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2))(@vitest/runner@4.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.2)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook: 10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
-      '@vitest/browser': 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2)
-      '@vitest/browser-playwright': 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(playwright@1.59.1)(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2)
+      '@vitest/browser': 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2)
+      '@vitest/browser-playwright': 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(playwright@1.59.1)(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2)
       '@vitest/runner': 4.1.2
-      vitest: 4.1.2(@types/node@25.3.3)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))
+      vitest: 4.1.2(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3))':
+  '@storybook/builder-vite@10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@22.19.19))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3))
+      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@22.19.19))
       storybook: 10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 7.3.1(@types/node@25.3.3)
+      vite: 7.3.1(@types/node@22.19.19)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3))':
+  '@storybook/csf-plugin@10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@22.19.19))':
     dependencies:
       storybook: 10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
       rollup: 4.59.0
-      vite: 7.3.1(@types/node@25.3.3)
+      vite: 7.3.1(@types/node@22.19.19)
 
   '@storybook/global@5.0.0': {}
 
@@ -2642,11 +2664,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.3.4(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3))':
+  '@storybook/react-vite@10.3.4(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.19))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.19))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@storybook/builder-vite': 10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3))
+      '@storybook/builder-vite': 10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@22.19.19))
       '@storybook/react': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -2656,7 +2678,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      vite: 7.3.1(@types/node@25.3.3)
+      vite: 7.3.1(@types/node@22.19.19)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -2737,7 +2759,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
-      '@types/node': 25.3.3
+      '@types/node': 22.19.19
 
   '@types/deep-eql@4.0.2': {}
 
@@ -2749,13 +2771,13 @@ snapshots:
 
   '@types/jsesc@2.5.1': {}
 
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
-
-  '@types/node@25.3.3':
-    dependencies:
-      undici-types: 7.18.2
 
   '@types/react@19.2.14':
     dependencies:
@@ -2773,29 +2795,29 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitest/browser-playwright@4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(playwright@1.59.1)(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2)':
+  '@vitest/browser-playwright@4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(playwright@1.59.1)(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2)':
     dependencies:
-      '@vitest/browser': 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2)
-      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))
+      '@vitest/browser': 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2)
+      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.3.3)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))
+      vitest: 4.1.2(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2)':
+  '@vitest/browser@4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))
+      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))
       '@vitest/utils': 4.1.2
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.3.3)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))
+      vitest: 4.1.2(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -2803,7 +2825,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.1.2(@vitest/browser@4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2))(vitest@4.1.2)':
+  '@vitest/coverage-v8@4.1.2(@vitest/browser@4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2))(vitest@4.1.2)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -2815,9 +2837,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.3.3)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))
+      vitest: 4.1.2(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))
     optionalDependencies:
-      '@vitest/browser': 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2)
+      '@vitest/browser': 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -2836,14 +2858,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))':
+  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.14(@types/node@25.3.3)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.3.3)
+      msw: 2.12.14(@types/node@22.19.19)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.19)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3330,9 +3352,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3):
+  msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3):
     dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@25.3.3)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.19)
       '@mswjs/interceptors': 0.41.3
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
@@ -3869,9 +3891,9 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
-  undici-types@7.16.0: {}
+  undici-types@6.21.0: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.16.0: {}
 
   unplugin@2.3.11:
     dependencies:
@@ -3900,7 +3922,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.1(@types/node@25.3.3):
+  vite@7.3.1(@types/node@22.19.19):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3909,13 +3931,13 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 22.19.19
       fsevents: 2.3.3
 
-  vitest@4.1.2(@types/node@25.3.3)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3)):
+  vitest@4.1.2(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3))
+      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -3932,11 +3954,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.3.3)
+      vite: 7.3.1(@types/node@22.19.19)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.3.3
-      '@vitest/browser-playwright': 4.1.2(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(playwright@1.59.1)(vite@7.3.1(@types/node@25.3.3))(vitest@4.1.2)
+      '@types/node': 22.19.19
+      '@vitest/browser-playwright': 4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(playwright@1.59.1)(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2)
     transitivePeerDependencies:
       - msw
 

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1,33 +1,56 @@
-// import type { MswApi } from './types'
 import type { ProjectAnnotations, Renderer } from 'storybook/internal/types'
 
-type MswApi = any
+import {
+  factoriesActive,
+  globalMswInstance,
+  setMswInstance,
+  userSetup,
+  type MswApi,
+} from './shared-state'
+import { legacyParametersDecorator } from './legacy'
 
 export type SetupFunction = () => MswApi | Promise<MswApi>
 
+// Lazy default, used when no setup is registered. The dynamic import keeps
+// `msw/browser` out of the bundle when the addon is installed but unused.
 const defaultSetup: SetupFunction = async () => {
   const { setupWorker } = await import('msw/browser')
   const worker = setupWorker()
   await worker.start({ quiet: true })
-  return worker
+  return worker as unknown as MswApi
 }
 
-let mswInstance: MswApi | undefined
+// --- annotations --------------------------------------------------------
 
 export function createPreviewAnnotations(
-  setup: SetupFunction = defaultSetup,
+  setup?: SetupFunction,
 ): ProjectAnnotations<Renderer> {
   return {
     async beforeEach(context) {
-      if (mswInstance == null) {
-        mswInstance = await setup()
+      if (globalMswInstance.current == null) {
+        // Precedence: explicit `setup` arg > `initialize()`'s `userSetup`
+        // > `defaultSetup`. Resolved here (not at construction) so an
+        // `initialize()` call in preview.ts is seen even if the addon's
+        // annotations were built first.
+        const effective: SetupFunction =
+          setup ??
+          (userSetup.current ? () => userSetup.current!() : defaultSetup)
+        setMswInstance(await effective())
       }
 
-      context.msw = mswInstance
+      ;(context as { msw?: MswApi }).msw = globalMswInstance.current!
 
       return () => {
-        context.msw?.resetHandlers()
+        globalMswInstance.current?.resetHandlers()
       }
     },
+    // Deprecated `parameters.msw` support — see `./legacy`. Remove the
+    // import and this entry after the `msw-storybook-migrate` cycle.
+    decorators: [legacyParametersDecorator],
   }
+}
+
+// Lets `initialize()` warn when factories is also configured.
+export function markFactoriesActive(): void {
+  factoriesActive.current = true
 }

--- a/src/csf3.ts
+++ b/src/csf3.ts
@@ -1,0 +1,2 @@
+// CSF 3.0 customization entry point
+export { initialize, type InitializeOptions } from './initialize'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,26 @@
 import { definePreviewAddon } from 'storybook/internal/csf'
-import { createPreviewAnnotations, type SetupFunction } from './addon'
 
+import {
+  createPreviewAnnotations,
+  markFactoriesActive,
+  type SetupFunction,
+} from './addon'
+// Pulls in the `StoryContext.msw` type augmentation from `types.ts`.
+import type {} from './types'
+
+export type { MswApi } from './shared-state'
+
+/**
+ * CSF factories entry point — use inside `definePreview({ addons: [...] })`.
+ *
+ * Pass an optional setup function to customise the worker (start options,
+ * initial handlers); it must return a started `SetupWorker`. If you're using CSF3,
+ * register the addon in `.storybook/main.ts` and use
+ * `initialize()` from `msw-storybook-addon/csf3` instead.
+ *
+ *     export default definePreview({ addons: [mswAddon()] })
+ */
 export default function addonMsw(setup?: SetupFunction) {
+  markFactoriesActive()
   return definePreviewAddon(createPreviewAnnotations(setup))
 }

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -1,0 +1,51 @@
+// CSF3 customization entry point: `initialize(options, handlers)` from
+// preview.ts pre-arms the worker before the addon's `beforeEach` builds
+// it. `setupWorker` is imported statically (not lazily like `defaultSetup`)
+// to keep the v1/v2 synchronous-return contract — `const { use } =
+// initialize(...)` must not break.
+
+import type { RequestHandler } from 'msw'
+import { setupWorker, type SetupWorker } from 'msw/browser'
+
+import { factoriesActive, userSetup } from './shared-state'
+
+export type InitializeOptions = Parameters<SetupWorker['start']>[0]
+
+export function initialize(
+  options?: InitializeOptions,
+  initialHandlers: RequestHandler[] = [],
+): SetupWorker {
+  if (factoriesActive.current) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[msw-storybook-addon] initialize() was called while CSF factories ' +
+          '(mswAddon() in definePreview) is also active. The initialize() ' +
+          'call is ignored — pass your setup as the argument to mswAddon() ' +
+          'instead.',
+      )
+    }
+    // Still return a started worker so `const instance = initialize(...)` is still supported for backwards compatibility reasons
+    const w = setupWorker(...initialHandlers)
+    w.start(options).catch(() => {})
+    return w
+  }
+
+  const worker = setupWorker(...initialHandlers)
+
+  // Start now, but keep the promise so the addon's `beforeEach` can await
+  // it — otherwise the first story's fetches race SW registration.
+  const ready = worker.start(options).catch((err: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error('[msw-storybook-addon] worker.start() failed:', err)
+  })
+
+  // Setup thunk for `addon.ts`: stories don't see the worker until
+  // `start()` resolves, even though it's returned synchronously here.
+  userSetup.current = async () => {
+    await ready
+    return worker as unknown as import('./shared-state').MswApi
+  }
+
+  return worker
+}

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -1,0 +1,72 @@
+// Legacy `parameters.msw` shim.
+//
+// Keeps v1/v2 (and half-migrated) codebases working until the codemod has
+// moved everything to `beforeEach({ msw })`. Everything in this file is
+// deprecated and meant to be deleted after the `msw-storybook-migrate`
+// deprecation cycle — kept isolated here so that removal is a one-file
+// delete plus dropping the `decorators` entry in `addon.ts`.
+//
+// Accepted `parameters.msw` shapes:
+//   - `msw: RequestHandler[]`                              (legacy array)
+//   - `msw: { handlers: RequestHandler[] }`
+//   - `msw: { handlers: Record<string, RequestHandler | RequestHandler[]> }`
+
+import type { DecoratorFunction, Renderer } from 'storybook/internal/types'
+import type { RequestHandler } from 'msw'
+
+import { globalMswInstance } from './shared-state'
+
+type MswParam =
+  | RequestHandler[]
+  | {
+      handlers?:
+        | RequestHandler[]
+        | Record<string, RequestHandler | RequestHandler[]>
+    }
+
+function resolveHandlers(param: MswParam): RequestHandler[] {
+  if (Array.isArray(param)) return param
+  if (param.handlers == null) return []
+  if (Array.isArray(param.handlers)) return param.handlers
+  return Object.values(param.handlers)
+    .filter(Boolean)
+    .flat() as RequestHandler[]
+}
+
+// This has to be a decorator: Storybook runs loaders and `beforeEach` both
+// *before* render, and a story's `parameters.msw` must override the
+// preview-level `beforeEach({ msw })` default — so the shim must run after
+// all `beforeEach`, which only a decorator (it runs during render) does.
+//
+// Unlike the old `mswDecorator`, this is NOT flaky: that flake was the
+// decorator racing service-worker registration. Here the worker is built
+// and awaited in `beforeEach` (which runs before any decorator), so by the
+// time this runs the SW is ready — it only places handlers.
+let warned = false
+
+export const legacyParametersDecorator: DecoratorFunction<Renderer> = (
+  storyFn,
+  context,
+) => {
+  const mswParam = (context.parameters as { msw?: MswParam })?.msw
+  const worker = globalMswInstance.current
+  if (mswParam != null && worker != null) {
+    const handlers = resolveHandlers(mswParam)
+    if (handlers.length > 0) {
+      // Warns in production too — intentionally annoying so the
+      // deprecation can't be ignored until `parameters.msw` is removed.
+      if (!warned) {
+        warned = true
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[msw-storybook-addon] `parameters.msw` is deprecated and will be ' +
+            'removed in a future major. It is applied at render, so it takes ' +
+            'precedence over `beforeEach({ msw })` — do not define both for ' +
+            'the same request. Run `npx msw-storybook-migrate` to migrate.',
+        )
+      }
+      worker.use(...handlers)
+    }
+  }
+  return storyFn()
+}

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,1 +1,6 @@
-export { createPreviewAnnotations } from './addon'
+// For CSF 3 projects, the preview annotations are auto-loaded by Storybook so this file is needed.
+import { createPreviewAnnotations } from './addon'
+
+export { createPreviewAnnotations }
+
+export default createPreviewAnnotations()

--- a/src/shared-state.ts
+++ b/src/shared-state.ts
@@ -1,0 +1,54 @@
+// Cross-module singleton state. Kept dependency-free (the SetupWorker
+// import is type-only) so it can live in the auto-loaded preview chunk
+// without pulling in `msw/browser`.
+
+import type { SetupWorker } from 'msw/browser'
+
+export type MswApi = SetupWorker
+
+// --- worker singleton ----------------------------------------------------
+
+export const globalMswInstance: { current: MswApi | null } = { current: null }
+
+// Reserved extension point for a future Storybook manager panel.
+//
+// The worker is created lazily in `addon.ts`'s `beforeEach`. A panel would
+// need a handle to it (to attach `worker.events.on(...)` listeners and
+// proxy MSW activity over the addon channel) but can't know whether it
+// registers before or after that creation. `onMswInstance` hides that
+// timing: subscribers are notified exactly once, immediately if the worker
+// already exists, otherwise when `setMswInstance` is called.
+//
+// There is no subscriber at the moment, but this will be an important piece when
+// we build an addon panel that shows MSW activity from stories.
+const instanceSubscribers = new Set<(worker: MswApi) => void>()
+
+export function setMswInstance(worker: MswApi): void {
+  globalMswInstance.current = worker
+  for (const cb of instanceSubscribers) {
+    try {
+      cb(worker)
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[msw-storybook-addon] instance subscriber threw:', err)
+    }
+  }
+}
+
+export function onMswInstance(cb: (worker: MswApi) => void): () => void {
+  // Fire immediately if the worker already exists, else wait for
+  // `setMswInstance`.
+  if (globalMswInstance.current) cb(globalMswInstance.current)
+  instanceSubscribers.add(cb)
+  return () => {
+    instanceSubscribers.delete(cb)
+  }
+}
+
+// --- setup overrides -----------------------------------------------------
+
+export const userSetup: {
+  current: (() => MswApi | Promise<MswApi>) | null
+} = { current: null }
+
+export const factoriesActive: { current: boolean } = { current: false }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,9 @@
+import type { MswApi } from './shared-state'
+
 declare module 'storybook/internal/csf' {
   interface StoryContext {
-    msw: number
+    msw: MswApi
   }
 }
 
-export {}
+export type { MswApi }

--- a/tests/base/.storybook/preview.ts
+++ b/tests/base/.storybook/preview.ts
@@ -5,9 +5,12 @@ import { http, HttpResponse } from 'msw'
 export default definePreview({
   addons: [addonMsw()],
   beforeEach({ msw }) {
+    // Default for every story unless overridden.
     msw.use(
       http.get('https://api.example.com/user', () => {
-        return HttpResponse.json({ name: 'John Maverick' })
+        return HttpResponse.json({
+          name: 'handler defined in preview beforeEach',
+        })
       }),
     )
   },

--- a/tests/base/base-handlers.test.ts
+++ b/tests/base/base-handlers.test.ts
@@ -5,7 +5,9 @@ test('uses the handlers from preview', async ({ page }) => {
   await page.getByRole('link', { name: 'Preview Handlers' }).click()
 
   const iframe = page.frameLocator('#storybook-preview-iframe')
-  await expect(iframe.getByRole('paragraph')).toHaveText('John Maverick')
+  await expect(iframe.getByRole('paragraph')).toHaveText(
+    'handler defined in preview beforeEach',
+  )
 })
 
 test('supports story-level handler overrides', async ({ page }) => {
@@ -13,7 +15,65 @@ test('supports story-level handler overrides', async ({ page }) => {
   await page.getByRole('link', { name: 'Per-Story Handlers' }).click()
 
   const iframe = page.frameLocator('#storybook-preview-iframe')
-  await expect(iframe.getByRole('paragraph')).toHaveText('Alice Sunwell')
+  await expect(iframe.getByRole('paragraph')).toHaveText(
+    'handler overriden in story beforeEach',
+  )
+})
+
+test('legacy handler defined in story with parameters.msw still works', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page
+    .getByRole('link', { name: 'Legacy parameters.msw (object form)' })
+    .click()
+
+  const iframe = page.frameLocator('#storybook-preview-iframe')
+  await expect(iframe.getByRole('paragraph')).toHaveText(
+    'legacy handler defined in story with parameters.msw',
+  )
+})
+
+test('legacy handler defined in story with parameters.msw array form still works', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page
+    .getByRole('link', { name: 'Legacy parameters.msw (array form)' })
+    .click()
+
+  const iframe = page.frameLocator('#storybook-preview-iframe')
+  await expect(iframe.getByRole('paragraph')).toHaveText(
+    'legacy handler defined in story with parameters.msw array form',
+  )
+})
+
+// Precedence footgun #1: `parameters.msw` and `beforeEach({ msw })` in the
+// same story — the deprecated param wins (decorator runs after beforeEach).
+test('parameters.msw beats beforeEach in the same story', async ({ page }) => {
+  await page.goto('/')
+  await page
+    .getByRole('link', { name: 'parameters.msw + beforeEach (same story)' })
+    .click()
+
+  const iframe = page.frameLocator('#storybook-preview-iframe')
+  await expect(iframe.getByRole('paragraph')).toHaveText('parameters.msw wins')
+})
+
+// Precedence footgun #2: a broad (meta-level) legacy `parameters.msw`
+// default silently overrides a migrated story-level `beforeEach({ msw })`.
+test('meta parameters.msw default beats a story beforeEach override', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page
+    .getByRole('link', { name: 'story beforeEach under meta parameters.msw' })
+    .click()
+
+  const iframe = page.frameLocator('#storybook-preview-iframe')
+  await expect(iframe.getByRole('paragraph')).toHaveText(
+    'meta parameters.msw default',
+  )
 })
 
 test('supports mocking an infinite loading state', async ({ page }) => {

--- a/tests/base/stories/base-handlers.stories.tsx
+++ b/tests/base/stories/base-handlers.stories.tsx
@@ -26,35 +26,77 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+// No handler here — falls back to the preview default.
 export const PreviewHandlers: Story = {
   async play({ canvas }) {
     await waitFor(async () => {
       await expect(canvas.getByRole('paragraph')).toHaveTextContent(
-        'John Maverick',
+        'handler defined in preview beforeEach',
       )
     })
   },
 }
 
+// Overrides the preview default for this story only.
 export const StoryOverrides: Story = {
   name: 'Per-Story Handlers',
   beforeEach({ msw }) {
     msw.use(
       http.get('https://api.example.com/user', () => {
-        return HttpResponse.json({ name: 'Alice Sunwell' })
+        return HttpResponse.json({ name: 'handler overriden in story beforeEach' })
       }),
     )
   },
   async play({ canvas }) {
     await waitFor(async () => {
       await expect(canvas.getByRole('paragraph')).toHaveTextContent(
-        'Alice Sunwell',
+        'handler overriden in story beforeEach',
       )
     })
   },
 }
 
-export const LoadingState: Story = {
+// Deprecated `parameters.msw`, still applied by the compat shim. Both the
+// object and bare-array forms must keep working.
+export const LegacyParametersObject: Story = {
+  name: 'Legacy parameters.msw (object form)',
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('https://api.example.com/user', () => {
+          return HttpResponse.json({ name: 'legacy handler defined in story with parameters.msw' })
+        }),
+      ],
+    },
+  },
+  async play({ canvas }) {
+    await waitFor(async () => {
+      await expect(canvas.getByRole('paragraph')).toHaveTextContent(
+        'legacy handler defined in story with parameters.msw',
+      )
+    })
+  },
+}
+
+export const LegacyParametersArray: Story = {
+  name: 'Legacy parameters.msw (array form)',
+  parameters: {
+    msw: [
+      http.get('https://api.example.com/user', () => {
+        return HttpResponse.json({ name: 'legacy handler defined in story with parameters.msw array form' })
+      }),
+    ],
+  },
+  async play({ canvas }) {
+    await waitFor(async () => {
+      await expect(canvas.getByRole('paragraph')).toHaveTextContent(
+        'legacy handler defined in story with parameters.msw array form',
+      )
+    })
+  },
+}
+
+export const DelayFunctionLoadingState: Story = {
   beforeEach({ msw }) {
     msw.use(
       http.get('https://api.example.com/user', async () => {

--- a/tests/base/stories/legacy-precedence.stories.tsx
+++ b/tests/base/stories/legacy-precedence.stories.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react'
+import { http, HttpResponse } from 'msw'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, waitFor } from 'storybook/test'
+
+function UserProfile() {
+  const [user, setUser] = useState<{ name: string } | null>(null)
+
+  useEffect(() => {
+    fetch('https://api.example.com/user')
+      .then((response) => response.json())
+      .then(setUser)
+  }, [])
+
+  if (!user) return <p>Loading...</p>
+
+  return <p>{user.name}</p>
+}
+
+// Pins the (deliberately surprising) precedence of the deprecated
+// `parameters.msw` shim vs `beforeEach({ msw })`. The shim applies at
+// render, after every `beforeEach`, so `parameters.msw` always wins.
+// Documented in MIGRATION.md — do not "fix" these by reordering.
+const meta = {
+  title: 'Scenarios',
+  component: UserProfile,
+  // Meta-level legacy default: stands in for a not-yet-migrated global.
+  parameters: {
+    msw: [
+      http.get('https://api.example.com/user', () =>
+        HttpResponse.json({ name: 'meta parameters.msw default' }),
+      ),
+    ],
+  },
+} satisfies Meta<typeof UserProfile>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// Same story defines BOTH. `parameters.msw` (decorator, runs last) wins
+// over the story's own `beforeEach({ msw })`. This is a footgun: the fix
+// is to delete the param and keep `beforeEach`.
+export const ParamAndBeforeEachSameStory: Story = {
+  name: 'parameters.msw + beforeEach (same story)',
+  parameters: {
+    msw: [
+      http.get('https://api.example.com/user', () =>
+        HttpResponse.json({ name: 'parameters.msw wins' }),
+      ),
+    ],
+  },
+  beforeEach({ msw }) {
+    msw.use(
+      http.get('https://api.example.com/user', () =>
+        HttpResponse.json({ name: 'beforeEach loses' }),
+      ),
+    )
+  },
+  async play({ canvas }) {
+    await waitFor(async () => {
+      await expect(canvas.getByRole('paragraph')).toHaveTextContent(
+        'parameters.msw wins',
+      )
+    })
+  },
+}
+
+// Broad (meta-level) legacy `parameters.msw` default vs a story-level
+// `beforeEach({ msw })` override. The un-migrated default still wins, so a
+// migrated story override is silently ignored until the default migrates
+// too.
+export const MigratedStoryUnderLegacyDefault: Story = {
+  name: 'story beforeEach under meta parameters.msw',
+  beforeEach({ msw }) {
+    msw.use(
+      http.get('https://api.example.com/user', () =>
+        HttpResponse.json({ name: 'story beforeEach override' }),
+      ),
+    )
+  },
+  async play({ canvas }) {
+    await waitFor(async () => {
+      await expect(canvas.getByRole('paragraph')).toHaveTextContent(
+        'meta parameters.msw default',
+      )
+    })
+  },
+}

--- a/tests/csf-3/.storybook/preview.ts
+++ b/tests/csf-3/.storybook/preview.ts
@@ -1,12 +1,19 @@
 import { http, HttpResponse } from 'msw'
-import type { ProjectAnnotations, Renderer } from 'storybook/internal/types'
+import { initialize } from 'msw-storybook-addon/csf3'
+
+// Exercise the CSF3 `initialize()` customization entry point: explicit
+// StartOptions + initial handlers passed at worker construction time.
+// `initialize(opts, [handler])` registers the handler on `setupWorker(...)`,
+// so it survives `resetHandlers()` between stories — i.e. it's a true
+// "preview-level default", not an `msw.use(...)` override.
+initialize({ onUnhandledRequest: 'bypass', quiet: true }, [
+  http.get('https://api.example.com/user', () => {
+    return HttpResponse.json({
+      name: 'initial handler defined in initialize() function',
+    })
+  }),
+])
 
 export default {
-  beforeEach({ msw }) {
-    msw.use(
-      http.get('https://api.example.com/user', () => {
-        return HttpResponse.json({ name: 'John Maverick' })
-      }),
-    )
-  },
-} satisfies ProjectAnnotations<Renderer>
+  tags: ['autodocs'],
+}

--- a/tests/csf-3/initialize.test.ts
+++ b/tests/csf-3/initialize.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+
+test('CSF3: uses initial handlers from initialize() in preview', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Preview Handlers' }).click()
+
+  const iframe = page.frameLocator('#storybook-preview-iframe')
+  await expect(iframe.getByRole('paragraph')).toHaveText(
+    'initial handler defined in initialize() function',
+  )
+})
+
+test('CSF3: supports per-story beforeEach({ msw }) overrides', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Per-Story Handlers' }).click()
+
+  const iframe = page.frameLocator('#storybook-preview-iframe')
+  await expect(iframe.getByRole('paragraph')).toHaveText(
+    'handler overriden in story beforeEach',
+  )
+})
+
+test('CSF3: resets to initial handlers between stories', async ({ page }) => {
+  await page.goto('/')
+  // visit a story that overrides, then a story that should fall back
+  await page.getByRole('link', { name: 'Per-Story Handlers' }).click()
+  await page.getByRole('link', { name: 'Resets To Initial Handlers' }).click()
+
+  const iframe = page.frameLocator('#storybook-preview-iframe')
+  await expect(iframe.getByRole('paragraph')).toHaveText(
+    'initial handler defined in initialize() function',
+  )
+})
+
+test('CSF3: supports infinite loading state', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Loading State' }).click()
+
+  const iframe = page.frameLocator('#storybook-preview-iframe')
+  await expect(iframe.getByRole('paragraph')).toHaveText('Loading...')
+
+  await page.waitForTimeout(500)
+  await expect(iframe.getByRole('paragraph')).toHaveText('Loading...')
+})

--- a/tests/csf-3/stories/csf-3.stories.tsx
+++ b/tests/csf-3/stories/csf-3.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { http, HttpResponse } from 'msw'
+import { http, HttpResponse, delay } from 'msw'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, waitFor } from 'storybook/test'
 
@@ -30,7 +30,7 @@ export const PreviewHandlers: Story = {
   async play({ canvas }) {
     await waitFor(async () => {
       await expect(canvas.getByRole('paragraph')).toHaveTextContent(
-        'John Maverick',
+        'initial handler defined in initialize() function',
       )
     })
   },
@@ -41,15 +41,42 @@ export const StoryOverrides: Story = {
   beforeEach({ msw }) {
     msw.use(
       http.get('https://api.example.com/user', () => {
-        return HttpResponse.json({ name: 'Alice Sunwell' })
+        return HttpResponse.json({ name: 'handler overriden in story beforeEach' })
       }),
     )
   },
   async play({ canvas }) {
     await waitFor(async () => {
       await expect(canvas.getByRole('paragraph')).toHaveTextContent(
-        'Alice Sunwell',
+        'handler overriden in story beforeEach',
       )
     })
+  },
+}
+
+// After a per-story override, the reset falls back to the `initialize()`
+// initial handlers — they survive `resetHandlers()`.
+export const ResetsToInitialHandlers: Story = {
+  async play({ canvas }) {
+    await waitFor(async () => {
+      await expect(canvas.getByRole('paragraph')).toHaveTextContent(
+        'initial handler defined in initialize() function',
+      )
+    })
+  },
+}
+
+export const LoadingState: Story = {
+  beforeEach({ msw }) {
+    msw.use(
+      http.get('https://api.example.com/user', async () => {
+        await delay('infinite')
+      }),
+    )
+  },
+  async play({ canvas }) {
+    await expect(canvas.getByRole('paragraph')).toHaveTextContent('Loading')
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    await expect(canvas.getByRole('paragraph')).toHaveTextContent('Loading')
   },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
     "module": "preserve",
     "moduleResolution": "bundler",
     "esModuleInterop": true,
-    "lib": ["ES2024"],
-  },
+    "lib": ["ES2024"]
+  }
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts', './src/preview.ts', './src/types.ts'],
+  // `shared-state.ts` is an explicit entry so it's one shared chunk —
+  // `./` and `initialize()` must see the same singletons at runtime.
+  entry: [
+    './src/index.ts',
+    './src/csf3.ts',
+    './src/preview.ts',
+    './src/shared-state.ts',
+    './src/types.ts',
+  ],
   outDir: './build',
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
This PR builds on top of `feat/v3` and provides support for CSF3 + customization use cases.

It also adds some docs, revamps the tests and storybooks, to guarantee we test all use cases we need.