### PR TITLE
feat: V3 API rework to support CSF3 and factories

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,7 @@
 <h1>Migration</h1>
 
 - [From 2.x.x to 3.x.x](#from-2xx-to-3xx)
+  - [Automated migration](#automated-migration)
   - [Handlers move from `parameters.msw` to `beforeEach({ msw })`](#handlers-move-from-parametersmsw-to-beforeeach-msw-)
   - [`mswLoader` and `mswDecorator` are removed](#mswloader-and-mswdecorator-are-removed)
   - [`initialize()` is now only for CSF 3.0 customization](#initialize-is-now-only-for-csf-30-customization)
@@ -17,6 +18,22 @@
 `beforeEach` hook. This removes the long-standing race where the service
 worker could fail to register before a story rendered: the worker is now
 started and awaited before any story (or its `play` function) runs.
+
+### Automated migration
+
+Run the bundled codemod from your project root:
+
+```sh
+npx msw-storybook-migrate
+```
+
+It rewrites recognised `parameters.msw` shapes into `beforeEach({ msw })`,
+removes `mswLoader` wiring from `.storybook/preview.*`, ensures
+`msw-storybook-addon` is in `.storybook/main.*` `addons`, and adds
+`mswAddon()` to `definePreview({ addons: [...] })` if you use CSF factories.
+Use `--dry-run` to preview changes, `--help` for options. Stories whose
+`parameters.msw` uses an unrecognised shape are reported and must be
+hand-migrated using the pattern below.
 
 ### Handlers move from `parameters.msw` to `beforeEach({ msw })`
 
@@ -45,7 +62,7 @@ top-level `beforeEach({ msw })`.
 The addon's `beforeEach` now builds and awaits the worker automatically, so
 there is nothing to register. Remove the `mswLoader`/`mswDecorator` import
 and any `loaders: [mswLoader]` / `decorators: [mswDecorator]` entry from
-`.storybook/preview.*`.
+`.storybook/preview.*` (the codemod does this for you).
 
 ### `initialize()` is now only for CSF 3.0 customization
 
@@ -62,7 +79,7 @@ free of `msw/browser`. Update the import:
 +import { initialize } from 'msw-storybook-addon/csf3'
 ```
 
-Other exports (`MswApi`, `InitializeOptions`) remain on the main
+Other exports like `MswApi` remain on the main
 `msw-storybook-addon` entry.
 
 ## From 1.x.x to 2.x.x

--- a/codemod/__tests__/main.test.ts
+++ b/codemod/__tests__/main.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { transformMain } from '../src/transforms/main'
+
+// Each test pins the full transformed output as an inline snapshot so the
+// exact rewrite is reviewable in the diff. Idempotent cases assert `null`
+// (the transform signals "nothing to do" by returning null).
+
+describe('transformMain', () => {
+  it('adds the addon when missing', () => {
+    const src = `import type { StorybookConfig } from '@storybook/react-vite'
+export default {
+  framework: '@storybook/react-vite',
+  stories: ['../src/**/*.stories.tsx'],
+  addons: ['@storybook/addon-essentials'],
+} satisfies StorybookConfig
+`
+    expect(transformMain(src)).toMatchInlineSnapshot(`
+      "import type { StorybookConfig } from '@storybook/react-vite'
+      export default {
+        framework: '@storybook/react-vite',
+        stories: ['../src/**/*.stories.tsx'],
+        addons: ['@storybook/addon-essentials', "msw-storybook-addon"],
+      } satisfies StorybookConfig
+      "
+    `)
+  })
+
+  it('is idempotent when the addon is already a bare string', () => {
+    const src = `export default {
+  addons: ['msw-storybook-addon'],
+}
+`
+    expect(transformMain(src)).toBeNull()
+  })
+
+  it('is idempotent when the addon is already in object form', () => {
+    const src = `export default {
+  addons: [{ name: 'msw-storybook-addon', options: {} }],
+}
+`
+    expect(transformMain(src)).toBeNull()
+  })
+
+  it('creates the addons array if missing', () => {
+    const src = `export default {
+  framework: '@storybook/react-vite',
+  stories: ['../src/**/*.stories.tsx'],
+}
+`
+    expect(transformMain(src)).toMatchInlineSnapshot(`
+      "export default {
+        framework: '@storybook/react-vite',
+        stories: ['../src/**/*.stories.tsx'],
+        addons: ["msw-storybook-addon"]
+      };
+      "
+    `)
+  })
+
+  it('returns null when addons is not a plain array (e.g. spread variable)', () => {
+    const src = `import { sharedAddons } from './shared'
+export default {
+  addons: sharedAddons,
+}
+`
+    expect(transformMain(src)).toBeNull()
+  })
+})

--- a/codemod/__tests__/preview.test.ts
+++ b/codemod/__tests__/preview.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest'
+import { transformPreview } from '../src/transforms/preview'
+
+// Each test pins the full transformed output as an inline snapshot so the
+// exact rewrite (import edits, loader removal, addon injection) is
+// reviewable in the diff. Idempotent cases assert `null`.
+
+describe('transformPreview', () => {
+  it('returns null when there is no msw-storybook-addon usage (idempotent)', () => {
+    const src = `
+      export default { parameters: {} }
+    `
+    expect(transformPreview(src)).toBeNull()
+  })
+
+  it('strips mswLoader from a CSF3 plain-object preview', () => {
+    const src = `import { initialize, mswLoader } from 'msw-storybook-addon'
+
+initialize({ onUnhandledRequest: 'bypass' })
+
+const preview = {
+  loaders: [mswLoader],
+  parameters: { actions: { argTypesRegex: '^on[A-Z].*' } },
+}
+export default preview
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import { initialize } from "msw-storybook-addon/csf3";
+
+      initialize({ onUnhandledRequest: 'bypass' })
+
+      const preview = {
+        parameters: { actions: { argTypesRegex: '^on[A-Z].*' } }
+      }
+      export default preview
+      "
+    `)
+  })
+
+  it('handles the loaders: mswLoader shorthand', () => {
+    const src = `import { initialize, mswLoader } from 'msw-storybook-addon'
+initialize()
+export default { loaders: mswLoader }
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import { initialize } from "msw-storybook-addon/csf3";
+      initialize()
+      export default {};
+      "
+    `)
+  })
+
+  it('keeps other loaders when mswLoader is one of many', () => {
+    const src = `import { initialize, mswLoader } from 'msw-storybook-addon'
+import { otherLoader } from 'somewhere'
+initialize()
+export default { loaders: [mswLoader, otherLoader] }
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import { initialize } from "msw-storybook-addon/csf3";
+      import { otherLoader } from 'somewhere'
+      initialize()
+      export default { loaders: [otherLoader] }
+      "
+    `)
+  })
+
+  it('leaves initialize() call sites alone regardless of arguments', () => {
+    // Real-world: function-form onUnhandledRequest closing over an outer const.
+    const src = `import { initialize, mswLoader } from 'msw-storybook-addon'
+const ignoredPattern = /\\.(png|svg)$/i
+initialize({
+  quiet: true,
+  onUnhandledRequest: ({ url }, print) => {
+    if (ignoredPattern.test(url)) return
+    print.warning()
+  },
+}, [])
+export default { loaders: [mswLoader] }
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import { initialize } from "msw-storybook-addon/csf3";
+      const ignoredPattern = /\\.(png|svg)$/i
+      initialize({
+        quiet: true,
+        onUnhandledRequest: ({ url }, print) => {
+          if (ignoredPattern.test(url)) return
+          print.warning()
+        },
+      }, [])
+      export default {};
+      "
+    `)
+  })
+
+  it('is idempotent — an already-migrated file is left untouched', () => {
+    const src = `import { initialize } from 'msw-storybook-addon/csf3'
+initialize()
+export default { parameters: {} }
+`
+    expect(transformPreview(src)).toBeNull()
+  })
+
+  it('moves a standalone initialize import to the /csf3 subpath', () => {
+    const src = `import { initialize } from 'msw-storybook-addon'
+initialize({ onUnhandledRequest: 'bypass' })
+export default { parameters: {} }
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import { initialize } from "msw-storybook-addon/csf3"
+      initialize({ onUnhandledRequest: 'bypass' })
+      export default { parameters: {} }
+      "
+    `)
+  })
+
+  it('moves an aliased initialize import to the /csf3 subpath', () => {
+    const src = `import { initialize as init } from 'msw-storybook-addon'
+init()
+export default { parameters: {} }
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import { initialize as init } from "msw-storybook-addon/csf3"
+      init()
+      export default { parameters: {} }
+      "
+    `)
+  })
+
+  it('strips mswDecorator (decorators array + shorthand)', () => {
+    const src = `import { initialize, mswDecorator } from 'msw-storybook-addon'
+import { other } from 'x'
+initialize()
+export default {
+  decorators: [mswDecorator, other],
+}
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import { initialize } from "msw-storybook-addon/csf3";
+      import { other } from 'x'
+      initialize()
+      export default {
+        decorators: [other],
+      }
+      "
+    `)
+  })
+
+  it('removes the decorators key when mswDecorator was the only one', () => {
+    const src = `import { initialize, mswDecorator } from 'msw-storybook-addon'
+initialize()
+export default { decorators: [mswDecorator] }
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import { initialize } from "msw-storybook-addon/csf3";
+      initialize()
+      export default {};
+      "
+    `)
+  })
+
+  // -- Factories path ----------------------------------------------------
+
+  it('factories: injects mswAddon() into definePreview addons if missing', () => {
+    const src = `import { definePreview } from '@storybook/react-vite'
+
+export default definePreview({
+  parameters: {},
+})
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import mswAddon from "msw-storybook-addon";
+      import { definePreview } from '@storybook/react-vite'
+
+      export default definePreview({
+        addons: [mswAddon()],
+        parameters: {}
+      })
+      "
+    `)
+  })
+
+  it('factories: leaves an already-registered mswAddon() alone', () => {
+    const src = `import { definePreview } from '@storybook/react-vite'
+import mswAddon from 'msw-storybook-addon'
+
+export default definePreview({
+  addons: [mswAddon()],
+})
+`
+    expect(transformPreview(src)).toBeNull()
+  })
+
+  it('factories: moves initialize to /csf3 and adds a separate mswAddon import', () => {
+    const src = `import { definePreview } from '@storybook/react-vite'
+import { initialize } from 'msw-storybook-addon'
+
+export default definePreview({
+  parameters: {},
+})
+`
+    expect(transformPreview(src)).toMatchInlineSnapshot(`
+      "import mswAddon from "msw-storybook-addon";
+      import { definePreview } from '@storybook/react-vite'
+      import { initialize } from "msw-storybook-addon/csf3"
+
+      export default definePreview({
+        addons: [mswAddon()],
+        parameters: {}
+      })
+      "
+    `)
+  })
+})

--- a/codemod/__tests__/stories.test.ts
+++ b/codemod/__tests__/stories.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest'
+import { transformStory } from '../src/transforms/stories'
+
+// Each test pins the full `transformStory` result as an inline snapshot so
+// the exact rewrite (parameters.msw -> beforeEach({ msw }), other params
+// preserved) and the skip behaviour are reviewable in the diff.
+
+describe('transformStory', () => {
+  it('returns null when the file has no parameters.msw (idempotent)', () => {
+    const src = `
+      import type { Meta, StoryObj } from '@storybook/react-vite'
+      const meta: Meta = { title: 'X' }
+      export default meta
+      export const Foo: StoryObj = { args: { x: 1 } }
+    `
+    expect(transformStory(src).code).toBeNull()
+  })
+
+  it('returns null when the file already uses beforeEach({ msw }) (idempotent)', () => {
+    const src = `
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach({ msw }) {
+          msw.use(http.get('/u', () => HttpResponse.json({})))
+        }
+      }
+    `
+    expect(transformStory(src).code).toBeNull()
+  })
+
+  it('migrates CSF3 story with parameters.msw.handlers (array)', () => {
+    const src = `import { http, HttpResponse } from 'msw'
+export default { title: 'X' }
+export const Foo = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/u', () => HttpResponse.json({ name: 'A' })),
+      ],
+    },
+  },
+}
+`
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach(
+          {
+            msw
+          }
+        ) {
+          msw.use(http.get('/u', () => HttpResponse.json({ name: 'A' })));
+        }
+      }
+      "
+    `)
+  })
+
+  it('migrates CSF3 meta-level parameters.msw', () => {
+    const src = `import { http, HttpResponse } from 'msw'
+const meta = {
+  title: 'X',
+  parameters: {
+    msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+  },
+}
+export default meta
+`
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      const meta = {
+        title: 'X',
+
+        beforeEach(
+          {
+            msw
+          }
+        ) {
+          msw.use(http.get('/u', () => HttpResponse.json({})));
+        }
+      }
+      export default meta
+      "
+    `)
+  })
+
+  it('migrates legacy array form parameters: { msw: [...handlers] }', () => {
+    const src = `import { http, HttpResponse } from 'msw'
+export default { title: 'X' }
+export const Foo = {
+  parameters: {
+    msw: [
+      http.get('/u', () => HttpResponse.json({})),
+    ],
+  },
+}
+`
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach(
+          {
+            msw
+          }
+        ) {
+          msw.use(http.get('/u', () => HttpResponse.json({})));
+        }
+      }
+      "
+    `)
+  })
+
+  it('flattens named-object handlers into msw.use(...)', () => {
+    const src = `import { http, HttpResponse } from 'msw'
+export default { title: 'X' }
+export const Foo = {
+  parameters: {
+    msw: {
+      handlers: {
+        user: [http.get('/u', () => HttpResponse.json({}))],
+        product: http.get('/p', () => HttpResponse.json({})),
+      },
+    },
+  },
+}
+`
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach(
+          {
+            msw
+          }
+        ) {
+          msw.use(
+            http.get('/u', () => HttpResponse.json({})),
+            http.get('/p', () => HttpResponse.json({}))
+          );
+        }
+      }
+      "
+    `)
+  })
+
+  it('preserves other parameters keys', () => {
+    const src = `import { http, HttpResponse } from 'msw'
+export default { title: 'X' }
+export const Foo = {
+  parameters: {
+    layout: 'centered',
+    msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+  },
+}
+`
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach(
+          {
+            msw
+          }
+        ) {
+          msw.use(http.get('/u', () => HttpResponse.json({})));
+        },
+
+        parameters: {
+          layout: 'centered'
+        }
+      }
+      "
+    `)
+  })
+
+  it('skips a story whose beforeEach already exists', () => {
+    const src = `import { http, HttpResponse } from 'msw'
+export default { title: 'X' }
+export const Foo = {
+  beforeEach() { /* user logic */ },
+  parameters: {
+    msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+  },
+}
+`
+    expect(transformStory(src)).toMatchInlineSnapshot(`
+      {
+        "code": null,
+        "skippedStories": [
+          "Foo",
+        ],
+      }
+    `)
+  })
+
+  it('skips an unrecognised parameters.msw shape', () => {
+    const src = `export default { title: 'X' }
+export const Foo = {
+  parameters: { msw: someExternalThing },
+}
+`
+    expect(transformStory(src)).toMatchInlineSnapshot(`
+      {
+        "code": null,
+        "skippedStories": [
+          "Foo",
+        ],
+      }
+    `)
+  })
+
+  it('preserves TypeScript type annotations (satisfies)', () => {
+    const src = `import { http, HttpResponse } from 'msw'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+const meta = { title: 'X' } satisfies Meta<unknown>
+export default meta
+type Story = StoryObj<typeof meta>
+export const Foo: Story = {
+  parameters: {
+    msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+  },
+}
+`
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      import type { Meta, StoryObj } from '@storybook/react-vite'
+      const meta = { title: 'X' } satisfies Meta<unknown>
+      export default meta
+      type Story = StoryObj<typeof meta>
+      export const Foo: Story = {
+        beforeEach(
+          {
+            msw
+          }
+        ) {
+          msw.use(http.get('/u', () => HttpResponse.json({})));
+        }
+      }
+      "
+    `)
+  })
+
+  it('migrates CSF2-style Foo.parameters = { msw: ... } annotation', () => {
+    const src = `import { http, HttpResponse } from 'msw'
+export default { title: 'X' }
+export const Foo = () => null
+Foo.parameters = {
+  msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+}
+`
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = () => null
+      Foo.beforeEach = (
+        {
+          msw
+        }
+      ) => {
+        msw.use(http.get('/u', () => HttpResponse.json({})));
+      };
+      "
+    `)
+  })
+})

--- a/codemod/src/bin.ts
+++ b/codemod/src/bin.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// CLI entry — `npx msw-storybook-migrate`.
+//
+// Walks the project for story files and the project's `.storybook/main.*`
+// and `preview.*` files, runs the three transforms, writes back.
+//
+// Args:
+//   --glob <pat>       Story-file glob.
+//                      Default: **/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}
+//   --preview <path>   Preview file. Auto-detected from .storybook/preview.*.
+//   --main <path>      Main config. Auto-detected from .storybook/main.*.
+//   --config-dir <d>   Storybook config directory. Default: .storybook.
+//   --dry-run          Don't write files; print what would change.
+
+import { promises as fs } from 'node:fs'
+import { existsSync } from 'node:fs'
+import os from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { logger } from 'storybook/internal/node-logger'
+import picocolors from 'picocolors'
+
+import { transformStory } from './transforms/stories'
+import { transformPreview } from './transforms/preview'
+import { transformMain } from './transforms/main'
+
+interface Args {
+  glob: string
+  preview: string | null
+  main: string | null
+  configDir: string
+  dryRun: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    glob: '**/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}',
+    preview: null,
+    main: null,
+    configDir: '.storybook',
+    dryRun: false,
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--dry-run') out.dryRun = true
+    else if (a === '--glob') out.glob = argv[++i] ?? out.glob
+    else if (a === '--preview') out.preview = argv[++i] ?? null
+    else if (a === '--main') out.main = argv[++i] ?? null
+    else if (a === '--config-dir') out.configDir = argv[++i] ?? out.configDir
+    else if (a === '--help' || a === '-h') {
+      printUsage()
+      process.exit(0)
+    }
+  }
+  return out
+}
+
+function printUsage(): void {
+  // eslint-disable-next-line no-console
+  console.log(`msw-storybook-migrate — migrate stories + preview.ts to the new API
+
+Usage: npx msw-storybook-migrate [options]
+
+  --glob <pattern>     Story-file glob. Default:
+                       **/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}
+  --preview <path>     Path to preview file. Auto-detected from --config-dir.
+  --main <path>        Path to main config. Auto-detected from --config-dir.
+  --config-dir <dir>   Storybook config directory. Default: .storybook
+  --dry-run            Don't write files; report what would change.
+  -h, --help           Show this help.
+`)
+}
+
+function findConfigFile(configDir: string, basename: string): string | null {
+  for (const ext of ['ts', 'tsx', 'mts', 'cts', 'js', 'jsx', 'mjs', 'cjs']) {
+    const p = join(configDir, `${basename}.${ext}`)
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  const cwd = process.cwd()
+  const configDir = resolve(cwd, args.configDir)
+
+  const previewPath = args.preview
+    ? resolve(cwd, args.preview)
+    : findConfigFile(configDir, 'preview')
+  const mainPath = args.main
+    ? resolve(cwd, args.main)
+    : findConfigFile(configDir, 'main')
+
+  let modified = 0
+  let unmodified = 0
+  let errors = 0
+  const warnings: string[] = []
+
+  // -- Stories
+  const { globby } = await import('globby')
+  // eslint-disable-next-line depend/ban-dependencies
+  const slash = (await import('slash')).default
+  const pLimit = (await import('p-limit')).default
+  const concurrency = Math.max(1, os.cpus().length - 1)
+  const limit = pLimit(concurrency)
+
+  const storyFiles = await globby(slash(args.glob), {
+    cwd,
+    followSymbolicLinks: true,
+    ignore: ['**/node_modules/**', '**/dist/**', '**/storybook-static/**', '**/build/**'],
+    absolute: true,
+  })
+
+  if (storyFiles.length === 0) {
+    logger.warn(`No story files matched glob "${args.glob}".`)
+  }
+
+  await Promise.all(
+    storyFiles.map((file: string) =>
+      limit(async () => {
+        try {
+          const source = await fs.readFile(file, 'utf-8')
+          const result = transformStory(source)
+          if (result.skippedStories.length > 0) {
+            warnings.push(
+              `  ${picocolors.yellow(short(file))}: ${result.skippedStories.join(', ')} ` +
+                `— parameters.msw shape not recognised; hand-migrate.`,
+            )
+          }
+          if (result.code != null && result.code !== source) {
+            if (!args.dryRun) await fs.writeFile(file, result.code, 'utf-8')
+            modified++
+            logger.log(picocolors.green(`  ✓ ${short(file)}`))
+          } else {
+            unmodified++
+          }
+        } catch (err) {
+          errors++
+          logger.error(`  ✗ ${short(file)}: ${String(err)}`)
+        }
+      }),
+    ),
+  )
+
+  // -- Preview
+  if (previewPath && existsSync(previewPath)) {
+    try {
+      const source = await fs.readFile(previewPath, 'utf-8')
+      const out = transformPreview(source)
+      if (out != null && out !== source) {
+        if (!args.dryRun) await fs.writeFile(previewPath, out, 'utf-8')
+        modified++
+        logger.log(picocolors.green(`  ✓ ${short(previewPath)}`))
+      } else {
+        unmodified++
+      }
+    } catch (err) {
+      errors++
+      logger.error(`  ✗ ${short(previewPath)}: ${String(err)}`)
+    }
+  } else if (args.preview) {
+    logger.warn(`Preview file not found: ${args.preview}`)
+  }
+
+  // -- Main
+  if (mainPath && existsSync(mainPath)) {
+    try {
+      const source = await fs.readFile(mainPath, 'utf-8')
+      const out = transformMain(source)
+      if (out != null && out !== source) {
+        if (!args.dryRun) await fs.writeFile(mainPath, out, 'utf-8')
+        modified++
+        logger.log(picocolors.green(`  ✓ ${short(mainPath)}`))
+      } else {
+        unmodified++
+      }
+    } catch (err) {
+      errors++
+      logger.error(`  ✗ ${short(mainPath)}: ${String(err)}`)
+    }
+  } else if (args.main) {
+    logger.warn(`Main config file not found: ${args.main}`)
+  }
+
+  logger.log('')
+  logger.log(
+    `Summary: ${picocolors.green(`${modified} transformed`)}, ` +
+      `${picocolors.dim(`${unmodified} unmodified`)}, ` +
+      `${errors > 0 ? picocolors.red(`${errors} errors`) : '0 errors'}`,
+  )
+
+  if (warnings.length > 0) {
+    logger.log('')
+    logger.warn(`${warnings.length} file(s) had stories the codemod could not migrate:`)
+    for (const w of warnings) logger.log(w)
+    logger.log(
+      `\n  These usually use a custom-shaped \`parameters.msw\` value. ` +
+        `See the migration guide in the addon's README for hand-migration steps.`,
+    )
+  }
+
+  if (args.dryRun) {
+    logger.log('')
+    logger.log(picocolors.bold(`Dry run — re-run without --dry-run to apply.`))
+  }
+
+  process.exit(errors > 0 ? 1 : 0)
+}
+
+function short(p: string): string {
+  const cwd = process.cwd()
+  return p.startsWith(cwd) ? p.slice(cwd.length + 1) : p
+}
+
+main().catch((err) => {
+  logger.error(String(err?.stack ?? err))
+  process.exit(1)
+})

--- a/codemod/src/transforms/main.ts
+++ b/codemod/src/transforms/main.ts
@@ -1,0 +1,82 @@
+// `.storybook/main.{js,ts}` transform.
+//
+// Single responsibility: ensure `'msw-storybook-addon'` is in the
+// `addons` array of the exported Storybook config. Required for the CSF3
+// path — the addon's `./preview` annotations are auto-loaded by Storybook
+// only when the package name appears in `main.ts addons`.
+//
+// Idempotent: if the entry already exists (as a bare string OR as the
+// object form `{ name: 'msw-storybook-addon', options: {...} }`), the
+// file isn't touched.
+
+import { types as t } from 'storybook/internal/babel'
+import { type ConfigFile, loadConfig, printConfig } from 'storybook/internal/csf-tools'
+
+const ADDON_PACKAGE = 'msw-storybook-addon'
+
+export function transformMain(source: string): string | null {
+  let parsed: ConfigFile
+  try {
+    parsed = loadConfig(source).parse()
+  } catch {
+    return null
+  }
+
+  const config = getConfigObject(parsed)
+  if (!config) return null
+
+  const addonsProp = findProperty(config, 'addons')
+
+  // No `addons` key → add one with our addon.
+  if (!addonsProp) {
+    config.properties.push(
+      t.objectProperty(
+        t.identifier('addons'),
+        t.arrayExpression([t.stringLiteral(ADDON_PACKAGE)]),
+      ),
+    )
+    return printConfig(parsed).code
+  }
+
+  if (!t.isArrayExpression(addonsProp.value)) {
+    // `addons` exists but isn't an array literal (e.g. a spread of a
+    // shared list). Refuse rather than guess.
+    return null
+  }
+
+  if (alreadyHasAddon(addonsProp.value)) {
+    return null
+  }
+  addonsProp.value.elements.push(t.stringLiteral(ADDON_PACKAGE))
+  return printConfig(parsed).code
+}
+
+function alreadyHasAddon(arr: t.ArrayExpression): boolean {
+  for (const el of arr.elements) {
+    if (!el) continue
+    if (t.isStringLiteral(el) && el.value === ADDON_PACKAGE) return true
+    if (t.isObjectExpression(el)) {
+      const name = findProperty(el, 'name')
+      if (name && t.isStringLiteral(name.value) && name.value.value === ADDON_PACKAGE) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function getConfigObject(parsed: ConfigFile): t.ObjectExpression | null {
+  const exports = parsed._exportsObject
+  if (exports && t.isObjectExpression(exports)) return exports
+  return null
+}
+
+function findProperty(obj: t.ObjectExpression, name: string): t.ObjectProperty | undefined {
+  for (const prop of obj.properties) {
+    if (!t.isObjectProperty(prop)) continue
+    const key = prop.key
+    if (t.isIdentifier(key) && key.name === name) return prop
+    if (t.isStringLiteral(key) && key.value === name) return prop
+  }
+  return undefined
+}

--- a/codemod/src/transforms/preview.ts
+++ b/codemod/src/transforms/preview.ts
@@ -1,0 +1,300 @@
+// `.storybook/preview.{js,ts,jsx,tsx}` transform.
+//
+// Responsibilities:
+//   1. Drop the legacy `mswLoader` / `mswDecorator` wiring — their named
+//      imports and any `loaders`/`decorators` references inside the preview
+//      default export. The `initialize` call itself is left strictly alone
+//      so users' real-world configs (custom StartOptions, function-form
+//      `onUnhandledRequest`, return-value destructuring, etc.) keep working.
+//   2. Move the `initialize` import to the `msw-storybook-addon/csf3`
+//      subpath (it's the CSF 3.0 customization entry point).
+//   3. If the user is on CSF factories — `definePreview({ addons: [...] })`
+//      — make sure `mswAddon()` is in the addons array, importing the
+//      default export if not already imported.
+//
+// Idempotent: running twice produces the same result and no spurious diff.
+
+import { types as t } from 'storybook/internal/babel'
+import { type ConfigFile, loadConfig, printConfig } from 'storybook/internal/csf-tools'
+
+const ADDON_PACKAGE = 'msw-storybook-addon'
+const CSF3_SUBPATH = 'msw-storybook-addon/csf3'
+
+function importedName(spec: t.ImportSpecifier): string | null {
+  const imported = spec.imported
+  return (
+    (t.isIdentifier(imported) && imported.name) ||
+    (t.isStringLiteral(imported) && imported.value) ||
+    null
+  )
+}
+
+export function transformPreview(source: string): string | null {
+  let parsed: ConfigFile
+  try {
+    parsed = loadConfig(source).parse()
+  } catch {
+    return null
+  }
+
+  let changed = false
+
+  // -- 1. Drop `mswLoader` / `mswDecorator` from imports.
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    if (stmt.source.value !== ADDON_PACKAGE) continue
+    const before = stmt.specifiers.length
+    stmt.specifiers = stmt.specifiers.filter((spec) => {
+      if (!t.isImportSpecifier(spec)) return true
+      const name = importedName(spec)
+      return name !== 'mswLoader' && name !== 'mswDecorator'
+    })
+    if (stmt.specifiers.length !== before) changed = true
+  }
+
+  // -- 1b. Move the `initialize` import to the `/csf3` subpath.
+  if (moveInitializeToCsf3(parsed)) changed = true
+
+  // Drop any import declaration that lost all its specifiers AND wasn't
+  // a side-effect import to begin with.
+  parsed._ast.program.body = parsed._ast.program.body.filter((stmt) => {
+    if (!t.isImportDeclaration(stmt)) return true
+    if (stmt.source.value !== ADDON_PACKAGE) return true
+    if (stmt.specifiers.length === 0) {
+      // Side-effect imports don't carry named specifiers, so an emptied
+      // declaration here always came from removing `mswLoader`/
+      // `mswDecorator` (initialize is retargeted, never emptied). Drop it.
+      changed = true
+      return false
+    }
+    return true
+  })
+
+  // -- 2. Walk the preview default export object (or the config inside
+  //   `definePreview(...)`) and drop `loaders`/`decorators` references.
+  const previewObj = getPreviewConfigObject(parsed)
+  if (previewObj) {
+    if (stripMswRef(previewObj, 'loaders', 'mswLoader')) changed = true
+    if (stripMswRef(previewObj, 'decorators', 'mswDecorator')) changed = true
+
+    // -- 3. Factories path: ensure mswAddon() is in `addons: [...]`.
+    if (isFactoriesPreview(parsed)) {
+      if (ensureFactoriesAddonRegistered(parsed, previewObj)) changed = true
+    }
+  }
+
+  return changed ? printConfig(parsed).code : null
+}
+
+// -------- discover the preview config object
+//
+// CSF3 plain object:        export default { ... }
+// CSF factories:            export default definePreview({ ... })
+// Variable + default:       const preview = {...}; export default preview;
+
+function getPreviewConfigObject(parsed: ConfigFile): t.ObjectExpression | null {
+  const exports = parsed._exportsObject
+  if (exports && t.isObjectExpression(exports)) return exports
+  // Look for `export default definePreview({...})` directly.
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isExportDefaultDeclaration(stmt)) continue
+    let decl: t.Node = stmt.declaration
+    if (t.isTSSatisfiesExpression(decl) || t.isTSAsExpression(decl)) decl = decl.expression
+    if (
+      t.isCallExpression(decl) &&
+      t.isIdentifier(decl.callee) &&
+      decl.callee.name === 'definePreview' &&
+      decl.arguments[0] &&
+      t.isObjectExpression(decl.arguments[0])
+    ) {
+      return decl.arguments[0]
+    }
+  }
+  return null
+}
+
+function isFactoriesPreview(parsed: ConfigFile): boolean {
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isExportDefaultDeclaration(stmt)) continue
+    let decl: t.Node = stmt.declaration
+    if (t.isTSSatisfiesExpression(decl) || t.isTSAsExpression(decl)) decl = decl.expression
+    if (
+      t.isCallExpression(decl) &&
+      t.isIdentifier(decl.callee) &&
+      decl.callee.name === 'definePreview'
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+// -------- move `initialize` to the `/csf3` subpath
+//
+// Splits the named `initialize` specifier off the `msw-storybook-addon`
+// import onto its own `import { initialize } from 'msw-storybook-addon/csf3'`.
+// Aliases (`initialize as init`) are preserved. If the import had no other
+// specifiers, its source is rewritten in place instead of leaving an empty
+// declaration. Idempotent: a `/csf3` import is left untouched (the loop
+// only matches `ADDON_PACKAGE`).
+
+function moveInitializeToCsf3(parsed: ConfigFile): boolean {
+  let changed = false
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    if (stmt.source.value !== ADDON_PACKAGE) continue
+
+    const initSpec = stmt.specifiers.find(
+      (s): s is t.ImportSpecifier =>
+        t.isImportSpecifier(s) && importedName(s) === 'initialize',
+    )
+    if (!initSpec) continue
+
+    if (stmt.specifiers.length === 1) {
+      // Only `initialize` — just retarget this declaration.
+      stmt.source = t.stringLiteral(CSF3_SUBPATH)
+    } else {
+      // Peel `initialize` off and add a dedicated `/csf3` import.
+      stmt.specifiers = stmt.specifiers.filter((s) => s !== initSpec)
+      mergeInitializeImport(parsed, initSpec)
+    }
+    changed = true
+  }
+  return changed
+}
+
+function mergeInitializeImport(
+  parsed: ConfigFile,
+  initSpec: t.ImportSpecifier,
+): void {
+  // Reuse an existing `/csf3` import if there already is one.
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    if (stmt.source.value !== CSF3_SUBPATH) continue
+    const has = stmt.specifiers.some(
+      (s) => t.isImportSpecifier(s) && importedName(s) === 'initialize',
+    )
+    if (!has) stmt.specifiers.push(initSpec)
+    return
+  }
+  parsed._ast.program.body.unshift(
+    t.importDeclaration([initSpec], t.stringLiteral(CSF3_SUBPATH)),
+  )
+}
+
+// -------- drop `mswLoader`/`mswDecorator` from `loaders`/`decorators`
+
+function stripMswRef(
+  obj: t.ObjectExpression,
+  propName: string,
+  refName: string,
+): boolean {
+  const prop = findProperty(obj, propName)
+  if (!prop) return false
+  const value = prop.value
+  // `loaders: mswLoader` / `decorators: mswDecorator` (single value)
+  if (t.isIdentifier(value) && value.name === refName) {
+    obj.properties = obj.properties.filter((p) => p !== prop)
+    return true
+  }
+  // `loaders: [mswLoader, ...others]`
+  if (t.isArrayExpression(value)) {
+    const before = value.elements.length
+    value.elements = value.elements.filter(
+      (el) => !(el && t.isIdentifier(el) && el.name === refName),
+    )
+    if (value.elements.length === 0 && before > 0) {
+      // Nothing left — remove the whole property.
+      obj.properties = obj.properties.filter((p) => p !== prop)
+      return true
+    }
+    return value.elements.length !== before
+  }
+  return false
+}
+
+// -------- factories: ensure mswAddon() is in addons array
+
+function ensureFactoriesAddonRegistered(
+  parsed: ConfigFile,
+  configObj: t.ObjectExpression,
+): boolean {
+  let changed = false
+  // Find the default-export identifier name for msw-storybook-addon, if any.
+  let mswAddonLocalName: string | null = null
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    if (stmt.source.value !== ADDON_PACKAGE) continue
+    for (const spec of stmt.specifiers) {
+      if (t.isImportDefaultSpecifier(spec)) {
+        mswAddonLocalName = spec.local.name
+      }
+    }
+  }
+  // If no default import exists, inject one (prefer reusing an existing
+  // msw-storybook-addon import declaration if one is still around).
+  if (!mswAddonLocalName) {
+    mswAddonLocalName = 'mswAddon'
+    let attached = false
+    for (const stmt of parsed._ast.program.body) {
+      if (!t.isImportDeclaration(stmt)) continue
+      if (stmt.source.value !== ADDON_PACKAGE) continue
+      stmt.specifiers.unshift(t.importDefaultSpecifier(t.identifier('mswAddon')))
+      attached = true
+      changed = true
+      break
+    }
+    if (!attached) {
+      parsed._ast.program.body.unshift(
+        t.importDeclaration(
+          [t.importDefaultSpecifier(t.identifier('mswAddon'))],
+          t.stringLiteral(ADDON_PACKAGE),
+        ),
+      )
+      changed = true
+    }
+  }
+
+  // Now make sure `addons` exists and contains `mswAddon()`.
+  let addonsProp = findProperty(configObj, 'addons')
+  if (!addonsProp) {
+    const arr = t.arrayExpression([
+      t.callExpression(t.identifier(mswAddonLocalName), []),
+    ])
+    configObj.properties.unshift(t.objectProperty(t.identifier('addons'), arr))
+    return true
+  }
+  if (!t.isArrayExpression(addonsProp.value)) return changed
+  const already = addonsProp.value.elements.some((el) => {
+    if (!el) return false
+    // mswAddon() — call expression with our identifier as callee
+    if (
+      t.isCallExpression(el) &&
+      t.isIdentifier(el.callee) &&
+      el.callee.name === mswAddonLocalName
+    )
+      return true
+    // bare identifier mswAddon — unusual but acceptable
+    if (t.isIdentifier(el) && el.name === mswAddonLocalName) return true
+    return false
+  })
+  if (!already) {
+    addonsProp.value.elements.unshift(
+      t.callExpression(t.identifier(mswAddonLocalName), []),
+    )
+    return true
+  }
+  return changed
+}
+
+// -------- helpers
+
+function findProperty(obj: t.ObjectExpression, name: string): t.ObjectProperty | undefined {
+  for (const prop of obj.properties) {
+    if (!t.isObjectProperty(prop)) continue
+    const key = prop.key
+    if (t.isIdentifier(key) && key.name === name) return prop
+    if (t.isStringLiteral(key) && key.value === name) return prop
+  }
+  return undefined
+}

--- a/codemod/src/transforms/stories.ts
+++ b/codemod/src/transforms/stories.ts
@@ -1,0 +1,370 @@
+// Story-file transform.
+//
+// Migrates `parameters.msw.handlers` (and its legacy shapes) into a
+// `beforeEach({ msw }) { msw.use(...) }` annotation. Idempotent: a file
+// that no longer carries `parameters.msw` is left untouched.
+//
+// Per the design discussion, we use the "recognised-shapes-only" rule
+// (option C): the transform inspects `parameters.msw` and only rewrites
+// when its shape is one of:
+//   - `RequestHandler[]`           (legacy v0 array form)
+//   - `{ handlers: RequestHandler[] }`
+//   - `{ handlers: Record<string, RequestHandler | RequestHandler[]> }`
+// Anything else (custom keys, dynamic values, etc.) is skipped and the
+// caller is told to print a warning so the user can hand-migrate.
+//
+// CSF3 (story-as-object) and CSF2 (post-export `Story.parameters = ...`
+// annotation) are both handled.
+
+import { types as t } from 'storybook/internal/babel'
+import { type CsfFile, loadCsf, printCsf } from 'storybook/internal/csf-tools'
+
+export interface StoryTransformResult {
+  /** Transformed source, or null when no changes were needed. */
+  code: string | null
+  /** Names of stories/files we refused to migrate because the
+   *  `parameters.msw` shape wasn't recognisable. The CLI surfaces these
+   *  as warnings so the user can hand-migrate. */
+  skippedStories: string[]
+}
+
+export function transformStory(source: string): StoryTransformResult {
+  const skipped: string[] = []
+  let parsed: CsfFile
+  try {
+    parsed = loadCsf(source, { makeTitle: (title?: string) => title || 'default' }).parse()
+  } catch {
+    // Not parseable as CSF — leave alone.
+    return { code: null, skippedStories: [] }
+  }
+
+  let changed = false
+
+  // CSF3: meta export + each story export are object literals — walk them.
+  for (const [name, decl] of Object.entries(parsed._storyExports)) {
+    const obj = getStoryObject(decl)
+    if (!obj) continue
+    const result = migrateMswOnObject(obj, name)
+    if (result === 'changed') changed = true
+    if (result === 'skipped') skipped.push(name)
+  }
+  if (parsed._metaPath) {
+    const meta = resolveStoryObject(parsed, parsed._metaPath.node)
+    if (meta) {
+      const result = migrateMswOnObject(meta, 'meta')
+      if (result === 'changed') changed = true
+      if (result === 'skipped') skipped.push('meta')
+    }
+  }
+
+  // CSF2: `Story.parameters = { msw: ... }` annotation statements at the
+  // top level of the file. The RHS of that assignment IS the parameters
+  // object — not a story object — so we need a different emit path that
+  // produces a parallel `Story.beforeEach = ({ msw }) => { msw.use(...) }`
+  // annotation rather than mutating an enclosing object literal.
+  for (let i = parsed._ast.program.body.length - 1; i >= 0; i--) {
+    const stmt = parsed._ast.program.body[i]
+    if (!isCsf2Annotation(stmt, parsed._storyExports)) continue
+    const assign = (stmt as t.ExpressionStatement).expression as t.AssignmentExpression
+    const left = assign.left as t.MemberExpression
+    const storyName = (left.object as t.Identifier).name
+    const propName =
+      (t.isIdentifier(left.property) && left.property.name) ||
+      (t.isStringLiteral(left.property) && left.property.value) ||
+      null
+    if (propName !== 'parameters') continue
+    if (!t.isObjectExpression(assign.right)) continue
+    const result = migrateCsf2Annotation(parsed, stmt as t.ExpressionStatement, storyName, i)
+    if (result === 'changed') changed = true
+    if (result === 'skipped') skipped.push(storyName)
+  }
+
+  if (!changed) {
+    return { code: null, skippedStories: skipped }
+  }
+  return { code: printCsf(parsed).code, skippedStories: skipped }
+}
+
+// -------- per-object migration
+
+type MigrationOutcome = 'changed' | 'skipped' | 'noop'
+
+function migrateMswOnObject(
+  obj: t.ObjectExpression,
+  storyName: string,
+): MigrationOutcome {
+  // Locate `parameters: { msw: ... }`.
+  const parametersProp = findObjectProperty(obj, 'parameters')
+  if (!parametersProp || !t.isObjectExpression(parametersProp.value)) return 'noop'
+  const parameters = parametersProp.value
+  const mswProp = findObjectProperty(parameters, 'msw')
+  if (!mswProp) return 'noop'
+
+  // Extract handlers list out of the recognised shapes.
+  const extracted = extractHandlers(mswProp.value)
+  if (!extracted) {
+    // Unrecognised shape — leave the file alone for THIS story.
+    return 'skipped'
+  }
+
+  // Refuse to silently overwrite an existing beforeEach. The user will
+  // hand-merge; we'd rather skip than blow away their code. `beforeEach`
+  // can appear as either a regular property (`beforeEach: () => {}`) or
+  // the method shorthand (`beforeEach() {}`); check for both.
+  if (hasAnyProperty(obj, 'beforeEach')) return 'skipped'
+
+  // Build `beforeEach({ msw }) { msw.use(...handlers) }`.
+  const beforeEachProp = buildBeforeEachProperty(extracted)
+  // Insert it BEFORE parameters so the migrated file reads naturally.
+  const insertIdx = obj.properties.indexOf(parametersProp)
+  obj.properties.splice(insertIdx, 0, beforeEachProp)
+
+  // Strip `msw` from `parameters`; drop `parameters` itself if empty.
+  parameters.properties = parameters.properties.filter((p) => p !== mswProp)
+  if (parameters.properties.length === 0) {
+    obj.properties = obj.properties.filter((p) => p !== parametersProp)
+  }
+  return 'changed'
+}
+
+// -------- handler extraction
+//
+// Returns an array of Expressions to spread into `msw.use(...)`, or null
+// if the shape isn't one we know how to migrate.
+
+function extractHandlers(value: t.Expression | t.PatternLike): t.Expression[] | null {
+  // Legacy array form: `parameters: { msw: [...handlers] }`
+  if (t.isArrayExpression(value)) {
+    return collectArrayElements(value)
+  }
+  // Object form: `parameters: { msw: { handlers: ... } }`
+  if (t.isObjectExpression(value)) {
+    const handlersProp = findObjectProperty(value, 'handlers')
+    if (!handlersProp) return null
+    const hv = handlersProp.value
+    // `handlers: [h1, h2]`
+    if (t.isArrayExpression(hv)) return collectArrayElements(hv)
+    // `handlers: { name1: h, name2: [h, h] }` — flatten the values.
+    if (t.isObjectExpression(hv)) {
+      const acc: t.Expression[] = []
+      for (const prop of hv.properties) {
+        if (!t.isObjectProperty(prop)) return null // spread/computed → unsupported
+        if (t.isArrayExpression(prop.value)) {
+          const elems = collectArrayElements(prop.value)
+          if (!elems) return null
+          acc.push(...elems)
+        } else if (isHandlerLikeExpression(prop.value)) {
+          acc.push(prop.value as t.Expression)
+        } else {
+          return null
+        }
+      }
+      return acc
+    }
+    return null
+  }
+  return null
+}
+
+function collectArrayElements(arr: t.ArrayExpression): t.Expression[] | null {
+  const acc: t.Expression[] = []
+  for (const el of arr.elements) {
+    if (el === null) return null // sparse array
+    if (t.isSpreadElement(el)) {
+      // Allow spreads like `...sharedHandlers` to flow through.
+      acc.push(el as unknown as t.Expression)
+      continue
+    }
+    if (!isHandlerLikeExpression(el)) return null
+    acc.push(el as t.Expression)
+  }
+  return acc
+}
+
+function isHandlerLikeExpression(node: t.Node): boolean {
+  // Anything that can sensibly be spread into `msw.use(...)` — calls,
+  // identifiers, member expressions, conditionals, etc. Reject literal
+  // primitives so we don't migrate something obviously wrong.
+  return !t.isStringLiteral(node) && !t.isNumericLiteral(node) && !t.isBooleanLiteral(node)
+}
+
+// -------- AST builders
+
+function buildBeforeEachProperty(handlers: t.Expression[]): t.ObjectMethod {
+  // beforeEach({ msw }) { msw.use(...handlers) }
+  const param = t.objectPattern([
+    t.objectProperty(t.identifier('msw'), t.identifier('msw'), false, true),
+  ])
+  const callArgs: (t.Expression | t.SpreadElement)[] = handlers.map((h) =>
+    t.isSpreadElement(h as unknown as t.Node) ? (h as unknown as t.SpreadElement) : (h as t.Expression),
+  )
+  const body = t.blockStatement([
+    t.expressionStatement(
+      t.callExpression(
+        t.memberExpression(t.identifier('msw'), t.identifier('use')),
+        callArgs,
+      ),
+    ),
+  ])
+  return t.objectMethod('method', t.identifier('beforeEach'), [param], body)
+}
+
+// -------- helpers
+
+function findObjectProperty(
+  obj: t.ObjectExpression,
+  name: string,
+): t.ObjectProperty | undefined {
+  for (const prop of obj.properties) {
+    if (!t.isObjectProperty(prop)) continue
+    const key = prop.key
+    if (t.isIdentifier(key) && key.name === name) return prop
+    if (t.isStringLiteral(key) && key.value === name) return prop
+  }
+  return undefined
+}
+
+// Like findObjectProperty but also matches `name() {}` method shorthand.
+function hasAnyProperty(obj: t.ObjectExpression, name: string): boolean {
+  for (const prop of obj.properties) {
+    if (t.isObjectProperty(prop) || t.isObjectMethod(prop)) {
+      const key = prop.key
+      if (t.isIdentifier(key) && key.name === name) return true
+      if (t.isStringLiteral(key) && key.value === name) return true
+    }
+  }
+  return false
+}
+
+function getStoryObject(node: t.Node): t.ObjectExpression | undefined {
+  if (t.isVariableDeclarator(node)) {
+    let init = node.init
+    if (t.isTSSatisfiesExpression(init) || t.isTSAsExpression(init)) init = init.expression
+    if (init && t.isObjectExpression(init)) return init
+  } else if (t.isExportDefaultDeclaration(node)) {
+    let init: t.Node | null | undefined = node.declaration
+    if (init && (t.isTSSatisfiesExpression(init) || t.isTSAsExpression(init))) init = init.expression
+    if (init && t.isObjectExpression(init)) return init
+  }
+  return undefined
+}
+
+// Resolve a "story object" through one level of indirection.
+//
+// CSF3 meta is commonly:
+//
+//     const meta = { ... }
+//     export default meta
+//
+// The CsfFile's `_metaPath` for that shape points at the
+// `export default meta` declaration, whose `.declaration` is an
+// `Identifier`. We follow the identifier back to its variable declarator
+// in the file's top-level body and return the underlying ObjectExpression.
+function resolveStoryObject(
+  parsed: CsfFile,
+  node: t.Node,
+): t.ObjectExpression | undefined {
+  const direct = getStoryObject(node)
+  if (direct) return direct
+  if (t.isExportDefaultDeclaration(node)) {
+    let decl: t.Node | null | undefined = node.declaration
+    if (decl && (t.isTSSatisfiesExpression(decl) || t.isTSAsExpression(decl))) {
+      decl = decl.expression
+    }
+    if (decl && t.isIdentifier(decl)) {
+      const ref = findVariableDeclarator(parsed, decl.name)
+      if (ref) return getStoryObject(ref)
+    }
+  }
+  return undefined
+}
+
+function findVariableDeclarator(
+  parsed: CsfFile,
+  name: string,
+): t.VariableDeclarator | undefined {
+  for (const stmt of parsed._ast.program.body) {
+    const decl = t.isExportNamedDeclaration(stmt) ? stmt.declaration : stmt
+    if (!decl || !t.isVariableDeclaration(decl)) continue
+    for (const d of decl.declarations) {
+      if (t.isIdentifier(d.id) && d.id.name === name) return d
+    }
+  }
+  return undefined
+}
+
+// CSF2 annotation: `Foo.parameters = { msw: { handlers: [...] } }`.
+//
+// We can't inject `beforeEach` into a story object (the export is a
+// function, not an object literal), so we emit a parallel sibling
+// annotation: `Foo.beforeEach = ({ msw }) => { msw.use(...) }`.
+function migrateCsf2Annotation(
+  parsed: CsfFile,
+  stmt: t.ExpressionStatement,
+  storyName: string,
+  stmtIndex: number,
+): MigrationOutcome {
+  const assign = stmt.expression as t.AssignmentExpression
+  const parametersObj = assign.right as t.ObjectExpression
+  const mswProp = findObjectProperty(parametersObj, 'msw')
+  if (!mswProp) return 'noop'
+
+  // Bail if a sibling `Foo.beforeEach = ...` annotation already exists.
+  for (const other of parsed._ast.program.body) {
+    if (!t.isExpressionStatement(other)) continue
+    const e = other.expression
+    if (!t.isAssignmentExpression(e)) continue
+    if (!t.isMemberExpression(e.left)) continue
+    if (!t.isIdentifier(e.left.object) || e.left.object.name !== storyName) continue
+    const propName =
+      (t.isIdentifier(e.left.property) && e.left.property.name) ||
+      (t.isStringLiteral(e.left.property) && e.left.property.value) ||
+      null
+    if (propName === 'beforeEach') return 'skipped'
+  }
+
+  const handlers = extractHandlers(mswProp.value)
+  if (!handlers) return 'skipped'
+
+  // Build the sibling assignment.
+  const param = t.objectPattern([
+    t.objectProperty(t.identifier('msw'), t.identifier('msw'), false, true),
+  ])
+  const body = t.blockStatement([
+    t.expressionStatement(
+      t.callExpression(
+        t.memberExpression(t.identifier('msw'), t.identifier('use')),
+        handlers as (t.Expression | t.SpreadElement)[],
+      ),
+    ),
+  ])
+  const beforeEachAssign = t.expressionStatement(
+    t.assignmentExpression(
+      '=',
+      t.memberExpression(t.identifier(storyName), t.identifier('beforeEach')),
+      t.arrowFunctionExpression([param], body),
+    ),
+  )
+
+  // Strip `msw` from the parameters object; drop the whole annotation
+  // statement if that empties it.
+  parametersObj.properties = parametersObj.properties.filter((p) => p !== mswProp)
+  if (parametersObj.properties.length === 0) {
+    parsed._ast.program.body.splice(stmtIndex, 1, beforeEachAssign)
+  } else {
+    parsed._ast.program.body.splice(stmtIndex + 1, 0, beforeEachAssign)
+  }
+  return 'changed'
+}
+
+function isCsf2Annotation(
+  stmt: t.Statement,
+  storyExports: Record<string, unknown>,
+): boolean {
+  if (!t.isExpressionStatement(stmt)) return false
+  const expr = stmt.expression
+  if (!t.isAssignmentExpression(expr)) return false
+  if (!t.isMemberExpression(expr.left)) return false
+  if (!t.isIdentifier(expr.left.object)) return false
+  return Boolean(storyExports[expr.left.object.name])
+}

--- a/codemod/tsconfig.json
+++ b/codemod/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./src", "./__tests__"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "jsx": "preserve",
+    "lib": ["ES2024"],
+    "types": ["node"]
+  }
+}

--- a/codemod/tsdown.config.ts
+++ b/codemod/tsdown.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'tsdown'
+
+// Codemod build. Emits a Node CLI binary plus the three transform
+// entries (each is a pure function, importable from automigration tools
+// later if needed).
+export default defineConfig({
+  entry: [
+    './src/bin.ts',
+    './src/transforms/stories.ts',
+    './src/transforms/preview.ts',
+    './src/transforms/main.ts',
+  ],
+  outDir: './dist',
+  format: ['esm'],
+  platform: 'node',
+  target: 'node18',
+  dts: false,
+  clean: true,
+  deps: {
+    // Storybook is a peer of the addon; never bundle it.
+    neverBundle: ['storybook'],
+  },
+})

--- a/codemod/vitest.config.ts
+++ b/codemod/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "storybook": {
     "displayName": "Mock Service Worker"
   },
+  "bin": {
+    "msw-storybook-migrate": "./codemod/dist/bin.mjs"
+  },
   "scripts": {
     "dev": "tsdown --watch",
     "lint": "publint",
@@ -31,11 +34,14 @@
     "test:stories": "playwright test",
     "test:stories:csf-3": "playwright test --config=playwright.csf-3.config.ts",
     "test:play": "vitest -c ./tests/base/vitest.config.ts --project storybook",
-    "build": "tsdown",
+    "test:codemod": "vitest -c ./codemod/vitest.config.ts run",
+    "build": "tsdown && pnpm build:codemod",
+    "build:codemod": "tsdown -c ./codemod/tsdown.config.ts",
     "release": "release publish"
   },
   "files": [
-    "./build"
+    "./build",
+    "./codemod/dist"
   ],
   "keywords": [
     "storybook-addon",
@@ -67,11 +73,15 @@
     "@types/react": "^19.2.14",
     "@vitest/browser-playwright": "4.1.2",
     "@vitest/coverage-v8": "4.1.2",
+    "globby": "^14.0.2",
     "msw": "^2.12.14",
     "msw-storybook-addon": "link:.",
+    "p-limit": "^6.1.0",
+    "picocolors": "^1.1.1",
     "publint": "^0.3.18",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "slash": "^5.1.0",
     "storybook": "^10.3.4",
     "tsdown": "^0.21.7",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,21 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.2
         version: 4.1.2(@vitest/browser@4.1.2(msw@2.12.14(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.19))(vitest@4.1.2))(vitest@4.1.2)
+      globby:
+        specifier: ^14.0.2
+        version: 14.1.0
       msw:
         specifier: ^2.12.14
         version: 2.12.14(@types/node@22.19.19)(typescript@5.9.3)
       msw-storybook-addon:
         specifier: link:.
         version: 'link:'
+      p-limit:
+        specifier: ^6.1.0
+        version: 6.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       publint:
         specifier: ^0.3.18
         version: 0.3.18
@@ -47,6 +56,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      slash:
+        specifier: ^5.1.0
+        version: 5.1.0
       storybook:
         specifier: ^10.3.4
         version: 10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -396,6 +408,18 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -691,6 +715,10 @@ packages:
 
   '@simple-libs/stream-utils@1.2.0':
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/merge-streams@2.3.0':
+    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
   '@standard-schema/spec@1.1.0':
@@ -999,6 +1027,10 @@ packages:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1205,6 +1237,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
@@ -1215,6 +1251,9 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1223,6 +1262,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -1259,9 +1302,17 @@ packages:
   git-log-parser@1.2.1:
     resolution: {integrity: sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==}
 
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  globby@14.1.0:
+    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
+    engines: {node: '>=18'}
 
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -1291,6 +1342,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
@@ -1314,9 +1369,17 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -1325,6 +1388,10 @@ packages:
 
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
@@ -1419,6 +1486,14 @@ packages:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1487,6 +1562,10 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -1500,6 +1579,10 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  path-type@6.0.0:
+    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
+    engines: {node: '>=18'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1509,6 +1592,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
@@ -1573,6 +1660,9 @@ packages:
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -1644,6 +1734,10 @@ packages:
   rettime@0.10.1:
     resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
@@ -1679,6 +1773,9 @@ packages:
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -1719,6 +1816,10 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
@@ -1874,6 +1975,10 @@ packages:
     resolution: {integrity: sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ==}
     hasBin: true
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -1946,6 +2051,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -2118,6 +2227,10 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
@@ -2420,6 +2533,18 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/logger@0.3.0':
@@ -2614,6 +2739,8 @@ snapshots:
     optional: true
 
   '@simple-libs/stream-utils@1.2.0': {}
+
+  '@sindresorhus/merge-streams@2.3.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2979,6 +3106,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
@@ -3168,11 +3299,23 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-redact@3.5.0: {}
 
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -3181,6 +3324,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   fsevents@2.3.2:
     optional: true
@@ -3211,11 +3358,24 @@ snapshots:
       through2: 2.0.5
       traverse: 0.6.8
 
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.4
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  globby@14.1.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 2.3.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      path-type: 6.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.3.0
 
   graceful-fs@4.2.10: {}
 
@@ -3235,6 +3395,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  ignore@7.0.5: {}
+
   import-without-cache@0.2.5: {}
 
   indent-string@4.0.0: {}
@@ -3249,13 +3411,21 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
 
   is-node-process@1.2.0: {}
+
+  is-number@7.0.0: {}
 
   is-wsl@3.1.1:
     dependencies:
@@ -3334,6 +3504,13 @@ snapshots:
 
   meow@13.2.0: {}
 
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.4:
@@ -3400,6 +3577,10 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   package-manager-detector@1.6.0: {}
 
   path-parse@1.0.7: {}
@@ -3411,11 +3592,15 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  path-type@6.0.0: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.3: {}
 
@@ -3499,6 +3684,8 @@ snapshots:
       once: 1.4.0
 
   quansync@1.0.0: {}
+
+  queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
 
@@ -3586,6 +3773,8 @@ snapshots:
 
   rettime@0.10.1: {}
 
+  reusify@1.1.0: {}
+
   rfdc@1.4.1: {}
 
   rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.12)(typescript@5.9.3):
@@ -3660,6 +3849,10 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -3687,6 +3880,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  slash@5.1.0: {}
 
   sonic-boom@2.8.0:
     dependencies:
@@ -3832,6 +4027,10 @@ snapshots:
     dependencies:
       tldts-core: 7.0.24
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   totalist@3.0.1: {}
 
   tough-cookie@6.0.0:
@@ -3894,6 +4093,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   unplugin@2.3.11:
     dependencies:
@@ -4023,5 +4224,7 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yocto-queue@1.2.2: {}
 
   yoctocolors-cjs@2.1.3: {}


### PR DESCRIPTION
Adds `npx msw-storybook-migrate` to move projects from the old
`parameters.msw` + `mswLoader`/`mswDecorator` setup to the v3 API.

It:
- rewrites recognized `parameters.msw` shapes into `beforeEach({ msw })`
- strips `mswLoader`/`mswDecorator` usage from `.storybook/preview.*`
- moves `import { initialize } from 'msw-storybook-addon'` to the
  `msw-storybook-addon/csf3` subpath
- ensures the addon is in `main.*` addons, and adds `mswAddon()` to
  `definePreview` when using CSF factories

If there are some unsupported `parameters.msw` shapes, they are reported for manual migration.

There are many tests but I will still do some proper manual QA tests with a canary release.