### PR TITLE
Provide codemod for migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .idea
 test-results
 storybook-static
+/codemod/node_modules

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,7 +21,7 @@ Most of this migration is automated: after upgrading the addon, run
 npx msw-storybook-migrate
 ```
 
-It rewrites your preview and main config, and can optionally migrate `parameters.msw` to `beforeEach` (pass `--parameters`, or answer the prompt). Anything it cannot migrate safely is listed for you to hand-migrate using the sections below.
+It rewrites your preview and main config, and migrates `parameters.msw` to `beforeEach` in your stories. Anything it cannot migrate safely is listed for you to migrate yourself using the sections below — and don't worry, `parameters.msw` keeps working until you do.
 
 ### Storybook required version is now 9 or higher
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,14 @@
 
 ## From 2.x.x to 3.x.x
 
+Most of this migration is automated: after upgrading the addon, run
+
+```sh
+npx msw-storybook-migrate
+```
+
+It rewrites your preview and main config, and can optionally migrate `parameters.msw` to `beforeEach` (pass `--parameters`, or answer the prompt). Anything it cannot migrate safely is listed for you to hand-migrate using the sections below.
+
 ### Storybook required version is now 9 or higher
 
 The addon now requires Storybook 9.0.0 or higher.

--- a/codemod/__tests__/main.test.ts
+++ b/codemod/__tests__/main.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import { transformMain } from '../src/transforms/main'
+import { dedent } from 'ts-dedent'
+
+describe('transformMain', () => {
+  it('adds the addon when missing', () => {
+    const src = dedent`
+      import type { StorybookConfig } from '@storybook/react-vite'
+      export default {
+        framework: '@storybook/react-vite',
+        stories: ['../src/**/*.stories.tsx'],
+        addons: ['@storybook/addon-essentials'],
+      } satisfies StorybookConfig
+    `
+    expect(transformMain(src)).toMatchInlineSnapshot(`
+      "import type { StorybookConfig } from '@storybook/react-vite'
+      export default {
+        framework: '@storybook/react-vite',
+        stories: ['../src/**/*.stories.tsx'],
+        addons: ['@storybook/addon-essentials', 'msw-storybook-addon'],
+      } satisfies StorybookConfig"
+    `)
+  })
+
+  it('is idempotent when the addon is already a bare string', () => {
+    const src = dedent`
+      export default {
+        addons: ['msw-storybook-addon'],
+      }
+    `
+    expect(transformMain(src)).toBeNull()
+  })
+
+  it('is idempotent when the addon is already in object form', () => {
+    const src = dedent`
+      export default {
+        addons: [{ name: 'msw-storybook-addon', options: {} }],
+      }
+    `
+    expect(transformMain(src)).toBeNull()
+  })
+
+  it('is idempotent when the addon is already wrapped in getAbsolutePath', () => {
+    const src = dedent`
+      function getAbsolutePath(value) {
+        return dirname(require.resolve(join(value, 'package.json')))
+      }
+      export default {
+        addons: [getAbsolutePath('msw-storybook-addon')],
+      }
+    `
+    expect(transformMain(src)).toBeNull()
+  })
+
+  it('is idempotent when the addon is in object form with a wrapped name', () => {
+    const src = dedent`
+      export default {
+        addons: [{ name: getAbsolutePath('msw-storybook-addon'), options: {} }],
+      }
+    `
+    expect(transformMain(src)).toBeNull()
+  })
+
+  it('follows the getAbsolutePath convention of existing entries', () => {
+    const src = dedent`
+      import type { StorybookConfig } from '@storybook/react-vite'
+      export default {
+        framework: getAbsolutePath('@storybook/react-vite'),
+        addons: [getAbsolutePath('@storybook/addon-docs')],
+      } satisfies StorybookConfig
+    `
+    expect(transformMain(src)).toMatchInlineSnapshot(`
+      "import type { StorybookConfig } from '@storybook/react-vite'
+      export default {
+        framework: getAbsolutePath('@storybook/react-vite'),
+        addons: [
+          getAbsolutePath('@storybook/addon-docs'),
+          getAbsolutePath('msw-storybook-addon')
+        ],
+      } satisfies StorybookConfig"
+    `)
+  })
+
+  it('follows any single-string-argument resolver convention, not just getAbsolutePath', () => {
+    const src = dedent`
+      export default {
+        addons: [wrapForPnp('@storybook/addon-docs')],
+      }
+    `
+    expect(transformMain(src)).toMatchInlineSnapshot(`
+      "export default {
+        addons: [wrapForPnp('@storybook/addon-docs'), wrapForPnp('msw-storybook-addon')],
+      }"
+    `)
+  })
+
+  it('handles a defineMain-wrapped config', () => {
+    const src = dedent`
+      import { defineMain } from '@storybook/react-vite/node'
+
+      export default defineMain({
+        framework: '@storybook/react-vite',
+        addons: ['@storybook/addon-docs'],
+      })
+    `
+    expect(transformMain(src)).toMatchInlineSnapshot(`
+      "import { defineMain } from '@storybook/react-vite/node'
+
+      export default defineMain({
+        framework: '@storybook/react-vite',
+        addons: ['@storybook/addon-docs', 'msw-storybook-addon'],
+      })"
+    `)
+  })
+
+  it('creates the addons array if missing', () => {
+    const src = dedent`
+      export default {
+        framework: '@storybook/react-vite',
+        stories: ['../src/**/*.stories.tsx'],
+      }
+    `
+    expect(transformMain(src)).toMatchInlineSnapshot(`
+      "export default {
+        framework: '@storybook/react-vite',
+        stories: ['../src/**/*.stories.tsx'],
+        addons: ['msw-storybook-addon']
+      };"
+    `)
+  })
+
+  it('returns null when addons is not a plain array (e.g. spread variable)', () => {
+    const src = dedent`
+      import { sharedAddons } from './shared'
+      export default {
+        addons: sharedAddons,
+      }
+    `
+    expect(transformMain(src)).toBeNull()
+  })
+})

--- a/codemod/__tests__/preview.test.ts
+++ b/codemod/__tests__/preview.test.ts
@@ -448,7 +448,7 @@ describe('transformPreview — parameters opt-in', () => {
     `
     const result = transformPreview(src, { migrateParameters: true })
     expect(result.warnings).toHaveLength(1)
-    expect(result.warnings[0]).toContain('not recognise')
+    expect(result.warnings[0]).toContain('not recognize')
     expect(result.code).toMatchInlineSnapshot(`
       "import { mswLoader } from "msw-storybook-addon/csf3";
       import { getHandlers } from './handlers'

--- a/codemod/__tests__/preview.test.ts
+++ b/codemod/__tests__/preview.test.ts
@@ -1,0 +1,682 @@
+import { describe, expect, it } from 'vitest'
+import { transformPreview } from '../src/transforms/preview'
+import { dedent } from 'ts-dedent'
+
+describe('transformPreview — CSF 3.0', () => {
+  it('returns null when there is no msw-storybook-addon usage', () => {
+    const result = transformPreview(`export default { parameters: {} }`)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toEqual([])
+  })
+
+  it('is idempotent — an already-migrated v3 file is left untouched', () => {
+    const src = dedent`
+      import { mswLoader } from 'msw-storybook-addon/csf3'
+
+      export default {
+        loaders: [mswLoader()],
+        parameters: {},
+      }
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toEqual([])
+  })
+
+  it('migrates the basic v2 wiring: bare initialize() + loaders: [mswLoader]', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+
+      initialize()
+
+      const preview = {
+        loaders: [mswLoader],
+        parameters: { actions: { argTypesRegex: '^on[A-Z].*' } },
+      }
+      export default preview
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { mswLoader } from "msw-storybook-addon/csf3";
+
+      const preview = {
+        loaders: [mswLoader()],
+        parameters: { actions: { argTypesRegex: '^on[A-Z].*' } },
+      }
+      export default preview"
+    `)
+  })
+
+  it('handles the loaders: mswLoader shorthand', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      initialize()
+      export default { loaders: mswLoader }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { mswLoader } from "msw-storybook-addon/csf3";
+      export default { loaders: [mswLoader()] }"
+    `)
+  })
+
+  it('keeps other loaders when mswLoader is one of many', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      import { otherLoader } from 'somewhere'
+      initialize()
+      export default { loaders: [mswLoader, otherLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { mswLoader } from "msw-storybook-addon/csf3";
+      import { otherLoader } from 'somewhere'
+      export default { loaders: [mswLoader(), otherLoader] }"
+    `)
+  })
+
+  it('folds initialize(options) into a setup function', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+
+      initialize({ onUnhandledRequest: 'bypass' })
+
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { setupWorker } from "msw/browser";
+      import { mswLoader } from "msw-storybook-addon/csf3";
+
+      export default { loaders: [mswLoader(async () => {
+        const worker = setupWorker();
+        await worker.start({ onUnhandledRequest: 'bypass' });
+        return worker;
+      })] }"
+    `)
+  })
+
+  it('folds a function-form onUnhandledRequest verbatim', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      const ignoredPattern = /\\.(png|svg)$/i
+      initialize({
+        quiet: true,
+        onUnhandledRequest: ({ url }, print) => {
+          if (ignoredPattern.test(url)) return
+          print.warning()
+        },
+      })
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { setupWorker } from "msw/browser";
+      import { mswLoader } from "msw-storybook-addon/csf3";
+      const ignoredPattern = /\\.(png|svg)$/i
+      export default { loaders: [mswLoader(async () => {
+        const worker = setupWorker();
+
+        await worker.start({
+          quiet: true,
+          onUnhandledRequest: ({ url }, print) => {
+            if (ignoredPattern.test(url)) return
+            print.warning()
+          },
+        });
+
+        return worker;
+      })] }"
+    `)
+  })
+
+  it('folds initialize(options, initialHandlers) — array form spreads into setupWorker', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+
+      initialize({ quiet: true }, [
+        http.get('/user', () => HttpResponse.json({ name: 'John' })),
+      ])
+
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { setupWorker } from "msw/browser";
+      import { http, HttpResponse } from 'msw'
+      import { mswLoader } from "msw-storybook-addon/csf3";
+
+      export default { loaders: [mswLoader(async () => {
+        const worker = setupWorker(http.get('/user', () => HttpResponse.json({ name: 'John' })));
+        await worker.start({ quiet: true });
+        return worker;
+      })] }"
+    `)
+  })
+
+  it('folds initialize(options, handlersIdentifier) — identifier is spread', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      import { sharedHandlers } from './handlers'
+
+      initialize({ quiet: true }, sharedHandlers)
+
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { setupWorker } from "msw/browser";
+      import { mswLoader } from "msw-storybook-addon/csf3";
+      import { sharedHandlers } from './handlers'
+
+      export default { loaders: [mswLoader(async () => {
+        const worker = setupWorker(...sharedHandlers);
+        await worker.start({ quiet: true });
+        return worker;
+      })] }"
+    `)
+  })
+
+  it('folds an aliased initialize import', () => {
+    const src = dedent`
+      import { initialize as init, mswLoader } from 'msw-storybook-addon'
+      init({ onUnhandledRequest: 'bypass' })
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { setupWorker } from "msw/browser";
+      import { mswLoader } from "msw-storybook-addon/csf3";
+      export default { loaders: [mswLoader(async () => {
+        const worker = setupWorker();
+        await worker.start({ onUnhandledRequest: 'bypass' });
+        return worker;
+      })] }"
+    `)
+  })
+
+  it('converts mswDecorator to a loader, keeping other decorators', () => {
+    const src = dedent`
+      import { initialize, mswDecorator } from 'msw-storybook-addon'
+      import { withTheme } from './theme'
+      initialize()
+      export default { decorators: [mswDecorator, withTheme] }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { mswLoader } from "msw-storybook-addon/csf3";
+      import { withTheme } from './theme'
+      export default {
+        loaders: [mswLoader()],
+        decorators: [withTheme]
+      };"
+    `)
+  })
+
+  it('drops the decorators key when mswDecorator was the only one', () => {
+    const src = dedent`
+      import { initialize, mswDecorator } from 'msw-storybook-addon'
+      initialize({ onUnhandledRequest: 'bypass' })
+      export default { decorators: [mswDecorator] }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { setupWorker } from "msw/browser";
+      import { mswLoader } from "msw-storybook-addon/csf3";
+      export default { loaders: [mswLoader(async () => {
+        const worker = setupWorker();
+        await worker.start({ onUnhandledRequest: 'bypass' });
+        return worker;
+      })] }"
+    `)
+  })
+
+  it('wires the loader for an initialize-only preview', () => {
+    const src = dedent`
+      import { initialize } from 'msw-storybook-addon'
+      initialize()
+      export default { parameters: {} }
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { mswLoader } from "msw-storybook-addon/csf3";
+      export default {
+        loaders: [mswLoader()],
+        parameters: {}
+      };"
+    `)
+  })
+
+  it('handles the "satisfies Preview" form', () => {
+    const src = dedent`
+      import type { Preview } from '@storybook/react-vite'
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+
+      initialize()
+
+      export default {
+        loaders: [mswLoader],
+      } satisfies Preview
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import type { Preview } from '@storybook/react-vite'
+      import { mswLoader } from "msw-storybook-addon/csf3";
+
+      export default {
+        loaders: [mswLoader()],
+      } satisfies Preview"
+    `)
+  })
+
+  it('skips and warns when the initialize return value is captured', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      const worker = initialize()
+      worker.use()
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('cannot rewrite')
+  })
+
+  it('skips and warns when initialize is called conditionally', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      if (process.env.NODE_ENV !== 'test') {
+        initialize()
+      }
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('cannot rewrite')
+  })
+
+  it('skips and warns on multiple initialize calls', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      initialize()
+      initialize({ quiet: true })
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('Multiple')
+  })
+
+  it('skips and warns on spread arguments to initialize', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      const args = [{ quiet: true }]
+      initialize(...args)
+      export default { loaders: [mswLoader] }
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+  })
+
+  it('skips and warns when the loader already carries a setup function', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon/csf3'
+      initialize({ quiet: true })
+      export default { loaders: [mswLoader(async () => myWorker)] }
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('setup function')
+  })
+})
+
+describe('transformPreview — parameters opt-in', () => {
+  it('does not touch parameters.msw without the option', () => {
+    const src = dedent`
+      import { mswLoader } from 'msw-storybook-addon/csf3'
+      import { http, HttpResponse } from 'msw'
+
+      export default {
+        loaders: [mswLoader()],
+        parameters: {
+          msw: [http.get('/user', () => HttpResponse.json({}))],
+        },
+      }
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toEqual([])
+  })
+
+  it('migrates preview-level parameters.msw (array form) to beforeEach', () => {
+    const src = dedent`
+      import { mswLoader } from 'msw-storybook-addon/csf3'
+      import { http, HttpResponse } from 'msw'
+
+      export default {
+        loaders: [mswLoader()],
+        parameters: {
+          msw: [http.get('/user', () => HttpResponse.json({}))],
+        },
+      }
+    `
+    const result = transformPreview(src, { migrateParameters: true })
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { mswLoader } from 'msw-storybook-addon/csf3'
+      import { http, HttpResponse } from 'msw'
+
+      export default {
+        loaders: [mswLoader()],
+
+        beforeEach({ msw }) {
+          msw.use(http.get('/user', () => HttpResponse.json({})))
+        }
+      };"
+    `)
+  })
+
+  it('migrates the handlers record form and keeps other parameters', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      import { http, HttpResponse } from 'msw'
+
+      initialize()
+
+      export default {
+        loaders: [mswLoader],
+        parameters: {
+          layout: 'centered',
+          msw: {
+            handlers: {
+              user: [http.get('/user', () => HttpResponse.json({}))],
+            },
+          },
+        },
+      }
+    `
+    const result = transformPreview(src, { migrateParameters: true })
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { mswLoader } from "msw-storybook-addon/csf3";
+      import { http, HttpResponse } from 'msw'
+
+      export default {
+        loaders: [mswLoader()],
+
+        beforeEach({ msw }) {
+          msw.use(http.get('/user', () => HttpResponse.json({})))
+        },
+
+        parameters: {
+          layout: 'centered'
+        }
+      };"
+    `)
+  })
+
+  it('warns on unrecognised parameters.msw shapes but still migrates the wiring', () => {
+    const src = dedent`
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+      import { getHandlers } from './handlers'
+
+      initialize()
+
+      export default {
+        loaders: [mswLoader],
+        parameters: {
+          msw: getHandlers(),
+        },
+      }
+    `
+    const result = transformPreview(src, { migrateParameters: true })
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('not recognise')
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { mswLoader } from "msw-storybook-addon/csf3";
+      import { getHandlers } from './handlers'
+
+      export default {
+        loaders: [mswLoader()],
+        parameters: {
+          msw: getHandlers(),
+        },
+      }"
+    `)
+  })
+
+  it('drops an empty parameters.msw without emitting a beforeEach', () => {
+    const src = dedent`
+      export default {
+        parameters: {
+          layout: 'centered',
+          msw: [],
+        },
+      }
+    `
+    const result = transformPreview(src, { migrateParameters: true })
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "export default {
+        parameters: {
+          layout: 'centered'
+        },
+      }"
+    `)
+  })
+
+  it('warns instead of overwriting an existing beforeEach', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+
+      export default {
+        beforeEach() {},
+        parameters: {
+          msw: [http.get('/user', () => HttpResponse.json({}))],
+        },
+      }
+    `
+    const result = transformPreview(src, { migrateParameters: true })
+    expect(result.code).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('already defines')
+  })
+})
+
+describe('transformPreview — CSF Next (definePreview)', () => {
+  it('leaves a definePreview file with no msw wiring untouched', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+
+      export default definePreview({
+        parameters: {},
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toEqual([])
+  })
+
+  it('leaves an already-registered addonMsw() alone', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon'
+
+      export default definePreview({
+        addons: [addonMsw()],
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toEqual([])
+  })
+
+  it('fixes the half-migrated state: strips a leftover loader next to addonMsw()', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon'
+      import { mswLoader } from 'msw-storybook-addon/csf3'
+
+      export default definePreview({
+        addons: [addonMsw()],
+        loaders: [mswLoader()],
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon'
+
+      export default definePreview({
+        addons: [addonMsw()]
+      })"
+    `)
+  })
+
+  it('treats a variable-declared definePreview as CSF Next', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+
+      initialize()
+
+      const preview = definePreview({
+        loaders: [mswLoader],
+      })
+
+      export default preview
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon';
+
+      const preview = definePreview({
+        addons: [addonMsw()],
+      })
+
+      export default preview"
+    `)
+  })
+
+  it('migrates full v2 wiring inside definePreview to addonMsw(setup)', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import { initialize, mswLoader } from 'msw-storybook-addon'
+
+      initialize({ onUnhandledRequest: 'bypass' })
+
+      export default definePreview({
+        loaders: [mswLoader],
+        parameters: {},
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { setupWorker } from "msw/browser";
+      import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon';
+
+      export default definePreview({
+        addons: [addonMsw(async () => {
+          const worker = setupWorker();
+          await worker.start({ onUnhandledRequest: 'bypass' });
+          return worker;
+        })],
+        parameters: {},
+      })"
+    `)
+  })
+
+  it('folds a bare initialize() into a plain addonMsw() registration', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import { initialize } from 'msw-storybook-addon'
+
+      initialize()
+
+      export default definePreview({
+        parameters: {},
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon';
+
+      export default definePreview({
+        addons: [addonMsw()],
+        parameters: {}
+      })"
+    `)
+  })
+
+  it('skips and warns when addonMsw already has a setup function to preserve', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon'
+      import { initialize } from 'msw-storybook-addon'
+
+      initialize({ quiet: true })
+
+      export default definePreview({
+        addons: [addonMsw(async () => myWorker)],
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('setup function')
+  })
+
+  it('migrates parameters.msw inside definePreview when opted in', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon'
+      import { http, HttpResponse } from 'msw'
+
+      export default definePreview({
+        addons: [addonMsw()],
+        parameters: {
+          msw: [http.get('/user', () => HttpResponse.json({}))],
+        },
+      })
+    `
+    const result = transformPreview(src, { migrateParameters: true })
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { definePreview } from '@storybook/react-vite'
+      import addonMsw from 'msw-storybook-addon'
+      import { http, HttpResponse } from 'msw'
+
+      export default definePreview({
+        addons: [addonMsw()],
+
+        beforeEach({ msw }) {
+          msw.use(http.get('/user', () => HttpResponse.json({})))
+        }
+      })"
+    `)
+  })
+})

--- a/codemod/__tests__/preview.test.ts
+++ b/codemod/__tests__/preview.test.ts
@@ -551,6 +551,147 @@ describe('transformPreview — CSF Next (definePreview)', () => {
     `)
   })
 
+  it('reports csfNext so the CLI can tailor its guidance', () => {
+    const csf3 = transformPreview(`export default { parameters: {} }`)
+    expect(csf3.csfNext).toBe(false)
+
+    const csfNext = transformPreview(
+      dedent`
+        import { definePreview } from '@storybook/react-vite'
+        export default definePreview({})
+      `
+    )
+    expect(csfNext.csfNext).toBe(true)
+  })
+
+  it('moves a loader-carried setup function onto addonMsw(setup)', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import { setupWorker } from 'msw/browser'
+      import { mswLoader } from 'msw-storybook-addon/csf3'
+
+      export default definePreview({
+        loaders: [mswLoader(async () => {
+          const worker = setupWorker()
+          await worker.start({ onUnhandledRequest: 'bypass' })
+          return worker
+        })],
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import addonMsw from "msw-storybook-addon";
+      import { definePreview } from '@storybook/react-vite'
+      import { setupWorker } from 'msw/browser'
+
+      export default definePreview({
+        addons: [addonMsw(async () => {
+          const worker = setupWorker()
+          await worker.start({ onUnhandledRequest: 'bypass' })
+          return worker
+        })],
+      })"
+    `)
+  })
+
+  it('cleans up the state left by `storybook automigrate csf-factories`', () => {
+    // The automigration injects a namespace import of the addon's /preview
+    // entry (a runtime no-op in v3) and keeps the old loader wiring.
+    const src = dedent`
+      import * as mswStorybookAddon from 'msw-storybook-addon/preview'
+      import { definePreview } from '@storybook/react-vite'
+      import { mswLoader } from 'msw-storybook-addon/csf3'
+
+      export default definePreview({
+        addons: [mswStorybookAddon],
+        loaders: [mswLoader()],
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import addonMsw from "msw-storybook-addon";
+      import { definePreview } from '@storybook/react-vite'
+
+      export default definePreview({
+        addons: [addonMsw()]
+      })"
+    `)
+  })
+
+  it('replaces an injected namespace entry even without leftover loader wiring', () => {
+    const src = dedent`
+      import * as mswStorybookAddon from 'msw-storybook-addon/preview'
+      import { definePreview } from '@storybook/react-vite'
+
+      export default definePreview({
+        addons: [mswStorybookAddon],
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import addonMsw from "msw-storybook-addon";
+      import { definePreview } from '@storybook/react-vite'
+
+      export default definePreview({
+        addons: [addonMsw()],
+      })"
+    `)
+  })
+
+  it('carries the loader setup when cleaning up the post-automigration state', () => {
+    const src = dedent`
+      import * as mswStorybookAddon from 'msw-storybook-addon/preview'
+      import { definePreview } from '@storybook/react-vite'
+      import { setupWorker } from 'msw/browser'
+      import { mswLoader } from 'msw-storybook-addon/csf3'
+
+      export default definePreview({
+        addons: [mswStorybookAddon],
+        loaders: [mswLoader(async () => {
+          const worker = setupWorker()
+          await worker.start({ quiet: true })
+          return worker
+        })],
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toMatchInlineSnapshot(`
+      "import addonMsw from "msw-storybook-addon";
+      import { definePreview } from '@storybook/react-vite'
+      import { setupWorker } from 'msw/browser'
+
+      export default definePreview({
+        addons: [addonMsw(async () => {
+          const worker = setupWorker()
+          await worker.start({ quiet: true })
+          return worker
+        })]
+      })"
+    `)
+  })
+
+  it('skips and warns when both initialize options and a loader setup exist', () => {
+    const src = dedent`
+      import { definePreview } from '@storybook/react-vite'
+      import { initialize } from 'msw-storybook-addon'
+      import { mswLoader } from 'msw-storybook-addon/csf3'
+
+      initialize({ quiet: true })
+
+      export default definePreview({
+        loaders: [mswLoader(async () => myWorker)],
+      })
+    `
+    const result = transformPreview(src)
+    expect(result.code).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('merge them into one')
+  })
+
   it('treats a variable-declared definePreview as CSF Next', () => {
     const src = dedent`
       import { definePreview } from '@storybook/react-vite'

--- a/codemod/__tests__/stories.test.ts
+++ b/codemod/__tests__/stories.test.ts
@@ -195,7 +195,10 @@ describe('transformStory', () => {
       {
         "code": null,
         "skippedStories": [
-          "Foo",
+          {
+            "reason": "existing-before-each",
+            "story": "Foo",
+          },
         ],
       }
     `)
@@ -212,7 +215,10 @@ describe('transformStory', () => {
       {
         "code": null,
         "skippedStories": [
-          "Foo",
+          {
+            "reason": "unrecognized-shape",
+            "story": "Foo",
+          },
         ],
       }
     `)
@@ -306,7 +312,10 @@ describe('transformStory', () => {
       {
         "code": null,
         "skippedStories": [
-          "Foo",
+          {
+            "reason": "existing-before-each",
+            "story": "Foo",
+          },
         ],
       }
     `)

--- a/codemod/__tests__/stories.test.ts
+++ b/codemod/__tests__/stories.test.ts
@@ -251,6 +251,55 @@ describe('transformStory', () => {
     `)
   })
 
+  it('migrates parameters.msw in CSF factory files (preview.meta / meta.story)', () => {
+    const src = dedent`
+      import preview from '../../../.storybook/preview'
+      import { http, HttpResponse } from 'msw'
+
+      const meta = preview.meta({
+        title: 'Pages/HomePage',
+        parameters: {
+          layout: 'fullscreen',
+          msw: {
+            handlers: [http.get('/x', () => HttpResponse.json({}))],
+          },
+        },
+      })
+
+      export const Default = meta.story()
+
+      export const WithParams = meta.story({
+        parameters: {
+          msw: [http.get('/y', () => HttpResponse.json({}))],
+        },
+      })
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import preview from '../../../.storybook/preview'
+      import { http, HttpResponse } from 'msw'
+
+      const meta = preview.meta({
+        title: 'Pages/HomePage',
+
+        beforeEach({ msw }) {
+          msw.use(http.get('/x', () => HttpResponse.json({})))
+        },
+
+        parameters: {
+          layout: 'fullscreen'
+        }
+      })
+
+      export const Default = meta.story()
+
+      export const WithParams = meta.story({
+        beforeEach({ msw }) {
+          msw.use(http.get('/y', () => HttpResponse.json({})))
+        }
+      })"
+    `)
+  })
+
   it('migrates the v1-style Foo.story = { parameters: { msw: ... } } annotation', () => {
     const src = dedent`
       import { http, HttpResponse } from 'msw'

--- a/codemod/__tests__/stories.test.ts
+++ b/codemod/__tests__/stories.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vitest'
+import { transformStory } from '../src/transforms/stories'
+import { dedent } from 'ts-dedent'
+
+// Each test pins the full `transformStory` result as an inline snapshot so
+// the exact rewrite (parameters.msw -> beforeEach({ msw }), other params
+// preserved) and the skip behaviour are reviewable in the diff.
+
+describe('transformStory', () => {
+  it('returns null when the file has no parameters.msw (idempotent)', () => {
+    const src = dedent`
+      import type { Meta, StoryObj } from '@storybook/react-vite'
+      const meta: Meta = { title: 'X' }
+      export default meta
+      export const Foo: StoryObj = { args: { x: 1 } }
+    `
+    expect(transformStory(src).code).toBeNull()
+  })
+
+  it('returns null when the file already uses beforeEach({ msw }) (idempotent)', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach({ msw }) {
+          msw.use(http.get('/u', () => HttpResponse.json({})))
+        }
+      }
+    `
+    expect(transformStory(src).code).toBeNull()
+  })
+
+  it('migrates CSF3 story with parameters.msw.handlers (array)', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        parameters: {
+          msw: {
+            handlers: [
+              http.get('/u', () => HttpResponse.json({ name: 'A' })),
+            ],
+          },
+        },
+      }
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach({ msw }) {
+          msw.use(http.get('/u', () => HttpResponse.json({ name: 'A' })))
+        }
+      }"
+    `)
+  })
+
+  it('migrates CSF3 meta-level parameters.msw', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      const meta = {
+        title: 'X',
+        parameters: {
+          msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+        },
+      }
+      export default meta
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      const meta = {
+        title: 'X',
+
+        beforeEach({ msw }) {
+          msw.use(http.get('/u', () => HttpResponse.json({})))
+        }
+      }
+      export default meta"
+    `)
+  })
+
+  it('migrates legacy array form parameters: { msw: [...handlers] }', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        parameters: {
+          msw: [
+            http.get('/u', () => HttpResponse.json({})),
+          ],
+        },
+      }
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach({ msw }) {
+          msw.use(http.get('/u', () => HttpResponse.json({})))
+        }
+      }"
+    `)
+  })
+
+  it('flattens named-object handlers into msw.use(...)', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        parameters: {
+          msw: {
+            handlers: {
+              user: [http.get('/u', () => HttpResponse.json({}))],
+              product: http.get('/p', () => HttpResponse.json({})),
+            },
+          },
+        },
+      }
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach({ msw }) {
+          msw.use(
+            http.get('/u', () => HttpResponse.json({})),
+            http.get('/p', () => HttpResponse.json({}))
+          )
+        }
+      }"
+    `)
+  })
+
+  it('preserves other parameters keys', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        parameters: {
+          layout: 'centered',
+          msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+        },
+      }
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach({ msw }) {
+          msw.use(http.get('/u', () => HttpResponse.json({})))
+        },
+
+        parameters: {
+          layout: 'centered'
+        }
+      }"
+    `)
+  })
+
+  it('drops an empty parameters.msw without emitting a beforeEach', () => {
+    const src = dedent`
+      export default { title: 'X' }
+      export const Foo = {
+        parameters: {
+          layout: 'centered',
+          msw: [],
+        },
+      }
+    `
+    expect(transformStory(src)).toMatchInlineSnapshot(`
+      {
+        "code": "export default { title: 'X' }
+      export const Foo = {
+        parameters: {
+          layout: 'centered'
+        },
+      }",
+        "skippedStories": [],
+      }
+    `)
+  })
+
+  it('skips a story whose beforeEach already exists', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = {
+        beforeEach() { /* user logic */ },
+        parameters: {
+          msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+        },
+      }
+    `
+    expect(transformStory(src)).toMatchInlineSnapshot(`
+      {
+        "code": null,
+        "skippedStories": [
+          "Foo",
+        ],
+      }
+    `)
+  })
+
+  it('skips an unrecognised parameters.msw shape', () => {
+    const src = dedent`
+      export default { title: 'X' }
+      export const Foo = {
+        parameters: { msw: someExternalThing },
+      }
+    `
+    expect(transformStory(src)).toMatchInlineSnapshot(`
+      {
+        "code": null,
+        "skippedStories": [
+          "Foo",
+        ],
+      }
+    `)
+  })
+
+  it('preserves TypeScript type annotations (satisfies)', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      import type { Meta, StoryObj } from '@storybook/react-vite'
+      const meta = { title: 'X' } satisfies Meta<unknown>
+      export default meta
+      type Story = StoryObj<typeof meta>
+      export const Foo: Story = {
+        parameters: {
+          msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+        },
+      }
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      import type { Meta, StoryObj } from '@storybook/react-vite'
+      const meta = { title: 'X' } satisfies Meta<unknown>
+      export default meta
+      type Story = StoryObj<typeof meta>
+      export const Foo: Story = {
+        beforeEach({ msw }) {
+          msw.use(http.get('/u', () => HttpResponse.json({})))
+        }
+      }"
+    `)
+  })
+
+  it('migrates the v1-style Foo.story = { parameters: { msw: ... } } annotation', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = () => null
+      Foo.story = {
+        name: 'Custom name',
+        parameters: {
+          msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+        },
+      }
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = () => null
+      Foo.story = {
+        name: 'Custom name'
+      }
+
+      Foo.beforeEach = ({ msw }) => {
+        msw.use(http.get('/u', () => HttpResponse.json({})))
+      };"
+    `)
+  })
+
+  it('drops a v1-style Foo.story annotation entirely when it empties', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = () => null
+      Foo.story = {
+        parameters: {
+          msw: [http.get('/u', () => HttpResponse.json({}))],
+        },
+      }
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = () => null
+      Foo.beforeEach = ({ msw }) => {
+        msw.use(http.get('/u', () => HttpResponse.json({})))
+      };"
+    `)
+  })
+
+  it('skips a CSF2 story that already has a beforeEach annotation', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = () => null
+      Foo.beforeEach = ({ msw }) => {}
+      Foo.parameters = {
+        msw: [http.get('/u', () => HttpResponse.json({}))],
+      }
+    `
+    expect(transformStory(src)).toMatchInlineSnapshot(`
+      {
+        "code": null,
+        "skippedStories": [
+          "Foo",
+        ],
+      }
+    `)
+  })
+
+  it('migrates CSF2-style Foo.parameters = { msw: ... } annotation', () => {
+    const src = dedent`
+      import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = () => null
+      Foo.parameters = {
+        msw: { handlers: [http.get('/u', () => HttpResponse.json({}))] },
+      }
+    `
+    expect(transformStory(src).code).toMatchInlineSnapshot(`
+      "import { http, HttpResponse } from 'msw'
+      export default { title: 'X' }
+      export const Foo = () => null
+      Foo.beforeEach = ({ msw }) => {
+        msw.use(http.get('/u', () => HttpResponse.json({})))
+      };"
+    `)
+  })
+})

--- a/codemod/src/bin.ts
+++ b/codemod/src/bin.ts
@@ -306,20 +306,24 @@ async function main(): Promise<void> {
     }
     if (unrecognizedShape.length > 0) {
       sections.push(
-        `These stories use a \`parameters.msw\` shape the codemod does not recognize — you will need to migrate them yourself:\n${unrecognizedShape
-          .map((w) => `• ${w}`)
+        `Could not recognize the \`parameters.msw\` shape — migrate them manually:\n${unrecognizedShape
+          .map((w) => `  • ${w}`)
           .join('\n')}`
       )
     }
     if (existingBeforeEach.length > 0) {
       sections.push(
-        `These stories already define \`beforeEach\` so were unmodified — you will need to move the \`parameters.msw\` handlers into it yourself:\n${existingBeforeEach
-          .map((w) => `• ${w}`)
+        `\`beforeEach\` already defined — migrate \`parameters.msw\` manually:\n${existingBeforeEach
+          .map((w) => `  • ${w}`)
           .join('\n')}`
       )
     }
+    sections.push(
+      "Don't worry — the addon still supports `parameters.msw`, so everything keeps working until you migrate."
+    )
+    sections.push(`See the migration guide:\n${CLI_COLORS.cta(MIGRATION_URL)}`)
     logger.warn(
-      `The codemod could not migrate everything:\n${sections.join('\n')}\nDon't worry — the addon still supports \`parameters.msw\`, so everything keeps working until you migrate.\nSee the migration guide:\n${CLI_COLORS.cta(MIGRATION_URL)}`
+      `The codemod could not migrate everything:\n${sections.join('\n\n')}`
     )
   }
 

--- a/codemod/src/bin.ts
+++ b/codemod/src/bin.ts
@@ -7,8 +7,7 @@
 //     subpath), `mswDecorator` → loader, `initialize(...)` folded into a
 //     setup function. CSF Next (`definePreview`) files get `addonMsw()`.
 //   - `.storybook/main.*`: registers `'msw-storybook-addon'` in `addons`.
-//   - Opt-in (prompted, or `--parameters` / `--no-parameters`): migrates
-//     `parameters.msw` to `beforeEach({ msw })` in stories and preview.
+//   - story files: migrates `parameters.msw` to `beforeEach({ msw })`.
 
 import { promises as fs } from 'node:fs'
 import { existsSync } from 'node:fs'
@@ -16,7 +15,7 @@ import os from 'node:os'
 import { join, relative, resolve, sep } from 'node:path'
 
 import { formatFileContent, globToRegexp } from 'storybook/internal/common'
-import { CLI_COLORS, logger, prompt } from 'storybook/internal/node-logger'
+import { CLI_COLORS, logger } from 'storybook/internal/node-logger'
 import { dedent } from 'ts-dedent'
 
 import { transformStory } from './transforms/stories'
@@ -33,8 +32,6 @@ interface Args {
   main: string | null
   configDir: string
   dryRun: boolean
-  /** null = undecided (prompt when interactive, default no otherwise). */
-  parameters: boolean | null
 }
 
 export function parseArgs(argv: string[]): Args {
@@ -43,14 +40,11 @@ export function parseArgs(argv: string[]): Args {
     preview: null,
     main: null,
     configDir: '.storybook',
-    dryRun: false,
-    parameters: null
+    dryRun: false
   }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--dry-run') out.dryRun = true
-    else if (a === '--parameters') out.parameters = true
-    else if (a === '--no-parameters') out.parameters = false
     else if (a === '--glob') out.glob = argv[++i] ?? out.glob
     else if (a === '--preview') out.preview = argv[++i] ?? null
     else if (a === '--main') out.main = argv[++i] ?? null
@@ -69,10 +63,7 @@ function printUsage(): void {
 
 Usage: npx msw-storybook-migrate [options]
 
-  --parameters         Also migrate \`parameters.msw\` to \`beforeEach({ msw })\`
-                       in stories and preview (skips the prompt).
-  --no-parameters      Keep \`parameters.msw\` as-is (skips the prompt).
-  --glob <pattern>     Story-file glob (used with --parameters). Default:
+  --glob <pattern>     Story-file glob. Default:
                        ${DEFAULT_GLOB}
   --preview <path>     Path to preview file. Auto-detected from --config-dir.
   --main <path>        Path to main config. Auto-detected from --config-dir.
@@ -88,20 +79,6 @@ function findConfigFile(configDir: string, basename: string): string | null {
     if (existsSync(p)) return p
   }
   return null
-}
-
-async function confirmParametersMigration(): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) return false
-  logger.log(
-    CLI_COLORS.muted(
-      'The `parameters.msw` approach is now deprecated, we advise to migrate to `beforeEach({ msw })` instead, which is more flexible and aligns with MSW practices.'
-    )
-  )
-  return prompt.confirm({
-    message:
-      'Migrate `parameters.msw` to `beforeEach({ msw })` in your stories and preview file?',
-    initialValue: true
-  })
 }
 
 const IGNORED_DIRS = new Set([
@@ -179,13 +156,14 @@ async function main(): Promise<void> {
     ? resolve(cwd, args.main)
     : findConfigFile(configDir, 'main')
 
-  const migrateParameters =
-    args.parameters ?? (await confirmParametersMigration())
-
   const transformed: string[] = []
   const failed: string[] = []
   let unmodified = 0
   const warnings: string[] = []
+  // Stories skipped by the story transform, grouped per reason so the final
+  // report explains each group once instead of repeating itself per file.
+  const unrecognizedShape: string[] = []
+  const existingBeforeEach: string[] = []
 
   let previewIsCsfNext: boolean | undefined
 
@@ -206,7 +184,7 @@ async function main(): Promise<void> {
   if (previewPath && existsSync(previewPath)) {
     try {
       const source = await fs.readFile(previewPath, 'utf-8')
-      const result = transformPreview(source, { migrateParameters })
+      const result = transformPreview(source, { migrateParameters: true })
       previewIsCsfNext = result.csfNext
       for (const w of result.warnings)
         warnings.push(`${short(previewPath)}: ${w}`)
@@ -258,47 +236,52 @@ async function main(): Promise<void> {
 
   flushPhase()
 
-  // -- Stories (opt-in)
-  if (migrateParameters) {
-    logger.step('Migrating `parameters.msw` in your story files...')
-    const limit = createLimiter(Math.max(1, os.cpus().length - 1))
+  // -- Stories
+  logger.step('Migrating `parameters.msw` in your story files...')
+  const limit = createLimiter(Math.max(1, os.cpus().length - 1))
 
-    const storyFiles = await findStoryFiles(cwd, args.glob)
+  const storyFiles = await findStoryFiles(cwd, args.glob)
 
-    if (storyFiles.length === 0) {
-      warnings.push(`No story files matched glob "${args.glob}".`)
-    }
+  if (storyFiles.length === 0) {
+    warnings.push(`No story files matched glob "${args.glob}".`)
+  }
 
-    await Promise.all(
-      storyFiles.map((file: string) =>
-        limit(async () => {
-          try {
-            const source = await fs.readFile(file, 'utf-8')
-            const result = transformStory(source)
-            if (result.skippedStories.length > 0) {
-              warnings.push(
-                `${short(file)}: ${result.skippedStories.join(', ')} — \`parameters.msw\` shape not recognised; hand-migrate.`
+  await Promise.all(
+    storyFiles.map((file: string) =>
+      limit(async () => {
+        try {
+          const source = await fs.readFile(file, 'utf-8')
+          const result = transformStory(source)
+          const shapes = result.skippedStories
+            .filter((s) => s.reason === 'unrecognized-shape')
+            .map((s) => s.story)
+          const merges = result.skippedStories
+            .filter((s) => s.reason === 'existing-before-each')
+            .map((s) => s.story)
+          if (shapes.length > 0) {
+            unrecognizedShape.push(`${short(file)}: ${shapes.join(', ')}`)
+          }
+          if (merges.length > 0) {
+            existingBeforeEach.push(`${short(file)}: ${merges.join(', ')}`)
+          }
+          if (result.code != null && result.code !== source) {
+            if (!args.dryRun) {
+              await fs.writeFile(
+                file,
+                await formatFileContent(file, result.code),
+                'utf-8'
               )
             }
-            if (result.code != null && result.code !== source) {
-              if (!args.dryRun) {
-                await fs.writeFile(
-                  file,
-                  await formatFileContent(file, result.code),
-                  'utf-8'
-                )
-              }
-              transformed.push(short(file))
-            } else {
-              unmodified++
-            }
-          } catch (err) {
-            failed.push(`${short(file)}: ${String(err)}`)
+            transformed.push(short(file))
+          } else {
+            unmodified++
           }
-        })
-      )
+        } catch (err) {
+          failed.push(`${short(file)}: ${String(err)}`)
+        }
+      })
     )
-  }
+  )
 
   flushPhase()
 
@@ -312,22 +295,41 @@ async function main(): Promise<void> {
     logger.error(failed.join('\n'))
   }
 
-  if (warnings.length > 0) {
+  const skippedAnything =
+    warnings.length > 0 ||
+    unrecognizedShape.length > 0 ||
+    existingBeforeEach.length > 0
+  if (skippedAnything) {
+    const sections: string[] = []
+    if (warnings.length > 0) {
+      sections.push(warnings.map((w) => `• ${w}`).join('\n'))
+    }
+    if (unrecognizedShape.length > 0) {
+      sections.push(
+        `These stories use a \`parameters.msw\` shape the codemod does not recognize — you will need to migrate them yourself:\n${unrecognizedShape
+          .map((w) => `• ${w}`)
+          .join('\n')}`
+      )
+    }
+    if (existingBeforeEach.length > 0) {
+      sections.push(
+        `These stories already define \`beforeEach\` so were unmodified — you will need to move the \`parameters.msw\` handlers into it yourself:\n${existingBeforeEach
+          .map((w) => `• ${w}`)
+          .join('\n')}`
+      )
+    }
     logger.warn(
-      `The codemod could not migrate everything:\n${warnings.map((w) => `• ${w}`).join('\n')}\nSee the migration guide for the manual steps:\n${CLI_COLORS.cta(MIGRATION_URL)}`
+      `The codemod could not migrate everything:\n${sections.join('\n')}\nDon't worry — the addon still supports \`parameters.msw\`, so everything keeps working until you migrate.\nSee the migration guide:\n${CLI_COLORS.cta(MIGRATION_URL)}`
     )
   }
 
   if (previewIsCsfNext === false) {
     logger.logBox(
       dedent`
-        All set — your project keeps using CSF 3.0 and works as-is.
+        All set, happy mocking!
 
-        When you are ready, we recommend upgrading to CSF Next with:
+        v3 of this addon was designed to work best with CSF Next, which you can migrate to with this command:
         ${CLI_COLORS.cta('npx storybook automigrate csf-factories')}
-
-        Then run ${CLI_COLORS.cta('npx msw-storybook-migrate')} once more and it will
-        move the addon to the new ${CLI_COLORS.cta('addonMsw()')} API for you.
 
         To learn more about CSF Next, see the Storybook docs:
         ${CLI_COLORS.cta('https://storybook.js.org/docs/api/csf/csf-next')}
@@ -336,18 +338,17 @@ async function main(): Promise<void> {
   } else if (previewIsCsfNext === true) {
     logger.logBox(
       dedent`
-        All set — your project uses CSF Next and the msw addon is
-        fully wired up via ${CLI_COLORS.cta('addonMsw()')}. Happy mocking!
+        All set. Happy mocking!
       `
     )
   } else {
     logger.logBox(
       dedent`
-        When you are ready to upgrade to CSF Next, run:
+        v3 of this addon was designed to work best with CSF Next, which you can migrate to with this command:
         ${CLI_COLORS.cta('npx storybook automigrate csf-factories')}
 
-        Then run ${CLI_COLORS.cta('npx msw-storybook-migrate')} once more to finish
-        the msw migration.
+        To learn more about CSF Next, see the Storybook docs:
+        ${CLI_COLORS.cta('https://storybook.js.org/docs/api/csf/csf-next')}
       `
     )
   }

--- a/codemod/src/bin.ts
+++ b/codemod/src/bin.ts
@@ -178,11 +178,14 @@ async function main(): Promise<void> {
   let errors = 0
   const warnings: string[] = []
 
+  let previewIsCsfNext: boolean | undefined
+
   // -- Preview
   if (previewPath && existsSync(previewPath)) {
     try {
       const source = await fs.readFile(previewPath, 'utf-8')
       const result = transformPreview(source, { migrateParameters })
+      previewIsCsfNext = result.csfNext
       for (const w of result.warnings) warnings.push(`  ${short(previewPath)}: ${w}`)
       if (result.code != null && result.code !== source) {
         if (!args.dryRun) {
@@ -279,9 +282,23 @@ async function main(): Promise<void> {
   }
 
   logger.log('')
-  logger.log(
-    'When you are ready to migrate to CSF Next entirely, run `npx storybook automigrate csf-factories` — the msw addon will be wired up automatically.',
-  )
+  if (previewIsCsfNext === false) {
+    logger.log(
+      'This project uses CSF 3.0 — the migrated setup keeps working as-is. When you are ready, it is advisable to migrate to CSF Next:',
+    )
+    logger.log('  npx storybook automigrate csf-factories')
+    logger.log(
+      'Afterwards, run `npx msw-storybook-migrate` again — it replaces the loader wiring with `addonMsw()` and finishes the msw migration.',
+    )
+  } else if (previewIsCsfNext === true) {
+    logger.log(
+      'This project uses CSF Next — the msw addon is fully wired up via `addonMsw()`.',
+    )
+  } else {
+    logger.log(
+      'When you are ready to migrate to CSF Next, run `npx storybook automigrate csf-factories`, then run `npx msw-storybook-migrate` again to finish the msw migration.',
+    )
+  }
 
   if (args.dryRun) {
     logger.log('')

--- a/codemod/src/bin.ts
+++ b/codemod/src/bin.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+// CLI entry — `npx msw-storybook-migrate` (shipped as a bin of the
+// `msw-storybook-addon` package, so it resolves from the local install).
+//
+// Migrates a v2 setup to v3:
+//   - `.storybook/preview.*`: `mswLoader` → `mswLoader()` (from the /csf3
+//     subpath), `mswDecorator` → loader, `initialize(...)` folded into a
+//     setup function. CSF Next (`definePreview`) files get `addonMsw()`.
+//   - `.storybook/main.*`: registers `'msw-storybook-addon'` in `addons`.
+//   - Opt-in (prompted, or `--parameters` / `--no-parameters`): migrates
+//     `parameters.msw` to `beforeEach({ msw })` in stories and preview.
+
+import { promises as fs } from 'node:fs'
+import { existsSync } from 'node:fs'
+import os from 'node:os'
+import { join, relative, resolve, sep } from 'node:path'
+import readline from 'node:readline/promises'
+
+import { formatFileContent, globToRegexp } from 'storybook/internal/common'
+import { logger } from 'storybook/internal/node-logger'
+
+import { transformStory } from './transforms/stories'
+import { transformPreview } from './transforms/preview'
+import { transformMain } from './transforms/main'
+
+const DEFAULT_GLOB = '**/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}'
+
+interface Args {
+  glob: string
+  preview: string | null
+  main: string | null
+  configDir: string
+  dryRun: boolean
+  /** null = undecided (prompt when interactive, default no otherwise). */
+  parameters: boolean | null
+}
+
+export function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    glob: DEFAULT_GLOB,
+    preview: null,
+    main: null,
+    configDir: '.storybook',
+    dryRun: false,
+    parameters: null,
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--dry-run') out.dryRun = true
+    else if (a === '--parameters') out.parameters = true
+    else if (a === '--no-parameters') out.parameters = false
+    else if (a === '--glob') out.glob = argv[++i] ?? out.glob
+    else if (a === '--preview') out.preview = argv[++i] ?? null
+    else if (a === '--main') out.main = argv[++i] ?? null
+    else if (a === '--config-dir') out.configDir = argv[++i] ?? out.configDir
+    else if (a === '--help' || a === '-h') {
+      printUsage()
+      process.exit(0)
+    }
+  }
+  return out
+}
+
+function printUsage(): void {
+  // eslint-disable-next-line no-console
+  console.log(`msw-storybook-migrate — migrate an msw-storybook-addon v2 setup to v3
+
+Usage: npx msw-storybook-migrate [options]
+
+  --parameters         Also migrate \`parameters.msw\` to \`beforeEach({ msw })\`
+                       in stories and preview (skips the prompt).
+  --no-parameters      Keep \`parameters.msw\` as-is (skips the prompt).
+  --glob <pattern>     Story-file glob (used with --parameters). Default:
+                       ${DEFAULT_GLOB}
+  --preview <path>     Path to preview file. Auto-detected from --config-dir.
+  --main <path>        Path to main config. Auto-detected from --config-dir.
+  --config-dir <dir>   Storybook config directory. Default: .storybook
+  --dry-run            Don't write files; report what would change.
+  -h, --help           Show this help.
+`)
+}
+
+function findConfigFile(configDir: string, basename: string): string | null {
+  for (const ext of ['ts', 'tsx', 'mts', 'cts', 'js', 'jsx', 'mjs', 'cjs']) {
+    const p = join(configDir, `${basename}.${ext}`)
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+async function confirmParametersMigration(): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const answer = await rl.question(
+      '`parameters.msw` keeps working in v3 (CSF 3.0 only) but is deprecated.\n' +
+        'Also migrate `parameters.msw` to `beforeEach({ msw })` in your stories and preview? [y/N] ',
+    )
+    return /^y(es)?$/i.test(answer.trim())
+  } finally {
+    rl.close()
+  }
+}
+
+const IGNORED_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'storybook-static',
+  '.git',
+])
+
+/** Recursive story-file finder — `globToRegexp` from storybook internals
+ *  plus a directory walk, so the CLI needs no glob dependency of its own. */
+async function findStoryFiles(cwd: string, glob: string): Promise<string[]> {
+  const pattern = globToRegexp(glob.replace(/\\/g, '/'))
+  const out: string[] = []
+
+  async function walk(dir: string): Promise<void> {
+    let entries
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    await Promise.all(
+      entries.map(async (entry) => {
+        const abs = join(dir, entry.name)
+        if (entry.isDirectory()) {
+          if (!IGNORED_DIRS.has(entry.name)) await walk(abs)
+        } else if (entry.isFile()) {
+          const rel = relative(cwd, abs).split(sep).join('/')
+          if (pattern.test(rel)) out.push(abs)
+        }
+      }),
+    )
+  }
+
+  await walk(cwd)
+  return out.sort()
+}
+
+/** Tiny concurrency limiter — avoids a p-limit dependency. */
+function createLimiter(concurrency: number) {
+  let active = 0
+  const queue: (() => void)[] = []
+  const next = () => {
+    active--
+    queue.shift()?.()
+  }
+  return async function limit<T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= concurrency) {
+      await new Promise<void>((resolveWait) => queue.push(resolveWait))
+    }
+    active++
+    try {
+      return await fn()
+    } finally {
+      next()
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  const cwd = process.cwd()
+  const configDir = resolve(cwd, args.configDir)
+
+  const previewPath = args.preview
+    ? resolve(cwd, args.preview)
+    : findConfigFile(configDir, 'preview')
+  const mainPath = args.main ? resolve(cwd, args.main) : findConfigFile(configDir, 'main')
+
+  const migrateParameters = args.parameters ?? (await confirmParametersMigration())
+
+  let modified = 0
+  let unmodified = 0
+  let errors = 0
+  const warnings: string[] = []
+
+  // -- Preview
+  if (previewPath && existsSync(previewPath)) {
+    try {
+      const source = await fs.readFile(previewPath, 'utf-8')
+      const result = transformPreview(source, { migrateParameters })
+      for (const w of result.warnings) warnings.push(`  ${short(previewPath)}: ${w}`)
+      if (result.code != null && result.code !== source) {
+        if (!args.dryRun) {
+          await fs.writeFile(previewPath, await formatFileContent(previewPath, result.code), 'utf-8')
+        }
+        modified++
+        logger.log(`  ✓ ${short(previewPath)}`)
+      } else {
+        unmodified++
+      }
+    } catch (err) {
+      errors++
+      logger.error(`  ✗ ${short(previewPath)}: ${String(err)}`)
+    }
+  } else {
+    logger.warn(
+      `Preview file not found${args.preview ? `: ${args.preview}` : ` in ${short(configDir)}`}.`,
+    )
+  }
+
+  // -- Main
+  if (mainPath && existsSync(mainPath)) {
+    try {
+      const source = await fs.readFile(mainPath, 'utf-8')
+      const out = transformMain(source)
+      if (out != null && out !== source) {
+        if (!args.dryRun) {
+          await fs.writeFile(mainPath, await formatFileContent(mainPath, out), 'utf-8')
+        }
+        modified++
+        logger.log(`  ✓ ${short(mainPath)}`)
+      } else {
+        unmodified++
+      }
+    } catch (err) {
+      errors++
+      logger.error(`  ✗ ${short(mainPath)}: ${String(err)}`)
+    }
+  } else {
+    logger.warn(
+      `Main config not found${args.main ? `: ${args.main}` : ` in ${short(configDir)}`}.`,
+    )
+  }
+
+  // -- Stories (opt-in)
+  if (migrateParameters) {
+    const limit = createLimiter(Math.max(1, os.cpus().length - 1))
+
+    const storyFiles = await findStoryFiles(cwd, args.glob)
+
+    if (storyFiles.length === 0) {
+      logger.warn(`No story files matched glob "${args.glob}".`)
+    }
+
+    await Promise.all(
+      storyFiles.map((file: string) =>
+        limit(async () => {
+          try {
+            const source = await fs.readFile(file, 'utf-8')
+            const result = transformStory(source)
+            if (result.skippedStories.length > 0) {
+              warnings.push(
+                `  ${short(file)}: ${result.skippedStories.join(', ')} — \`parameters.msw\` shape not recognised; hand-migrate.`,
+              )
+            }
+            if (result.code != null && result.code !== source) {
+              if (!args.dryRun) {
+                await fs.writeFile(file, await formatFileContent(file, result.code), 'utf-8')
+              }
+              modified++
+              logger.log(`  ✓ ${short(file)}`)
+            } else {
+              unmodified++
+            }
+          } catch (err) {
+            errors++
+            logger.error(`  ✗ ${short(file)}: ${String(err)}`)
+          }
+        }),
+      ),
+    )
+  }
+
+  logger.log('')
+  logger.log(
+    `Summary: ${modified} transformed, ${unmodified} unmodified, ${errors} error(s)`,
+  )
+
+  if (warnings.length > 0) {
+    logger.log('')
+    logger.warn(`${warnings.length} thing(s) the codemod could not migrate:`)
+    for (const w of warnings) logger.log(w)
+    logger.log('  See MIGRATION.md in the msw-storybook-addon repository for hand-migration steps.')
+  }
+
+  logger.log('')
+  logger.log(
+    'When you are ready to migrate to CSF Next entirely, run `npx storybook automigrate csf-factories` — the msw addon will be wired up automatically.',
+  )
+
+  if (args.dryRun) {
+    logger.log('')
+    logger.log('Dry run — re-run without --dry-run to apply.')
+  }
+
+  process.exit(errors > 0 ? 1 : 0)
+}
+
+function short(p: string): string {
+  const cwd = process.cwd()
+  return p.startsWith(cwd) ? p.slice(cwd.length + 1) : p
+}
+
+main().catch((err) => {
+  logger.error(String((err as Error)?.stack ?? err))
+  process.exit(1)
+})

--- a/codemod/src/bin.ts
+++ b/codemod/src/bin.ts
@@ -14,16 +14,18 @@ import { promises as fs } from 'node:fs'
 import { existsSync } from 'node:fs'
 import os from 'node:os'
 import { join, relative, resolve, sep } from 'node:path'
-import readline from 'node:readline/promises'
 
 import { formatFileContent, globToRegexp } from 'storybook/internal/common'
-import { logger } from 'storybook/internal/node-logger'
+import { CLI_COLORS, logger, prompt } from 'storybook/internal/node-logger'
+import { dedent } from 'ts-dedent'
 
 import { transformStory } from './transforms/stories'
 import { transformPreview } from './transforms/preview'
 import { transformMain } from './transforms/main'
 
 const DEFAULT_GLOB = '**/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}'
+const MIGRATION_URL =
+  'https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#from-2xx-to-3xx'
 
 interface Args {
   glob: string
@@ -42,7 +44,7 @@ export function parseArgs(argv: string[]): Args {
     main: null,
     configDir: '.storybook',
     dryRun: false,
-    parameters: null,
+    parameters: null
   }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
@@ -90,16 +92,16 @@ function findConfigFile(configDir: string, basename: string): string | null {
 
 async function confirmParametersMigration(): Promise<boolean> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) return false
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
-  try {
-    const answer = await rl.question(
-      '`parameters.msw` keeps working in v3 (CSF 3.0 only) but is deprecated.\n' +
-        'Also migrate `parameters.msw` to `beforeEach({ msw })` in your stories and preview? [y/N] ',
+  logger.log(
+    CLI_COLORS.muted(
+      'The `parameters.msw` approach is now deprecated, we advise to migrate to `beforeEach({ msw })` instead, which is more flexible and aligns with MSW practices.'
     )
-    return /^y(es)?$/i.test(answer.trim())
-  } finally {
-    rl.close()
-  }
+  )
+  return prompt.confirm({
+    message:
+      'Migrate `parameters.msw` to `beforeEach({ msw })` in your stories and preview file?',
+    initialValue: true
+  })
 }
 
 const IGNORED_DIRS = new Set([
@@ -107,7 +109,7 @@ const IGNORED_DIRS = new Set([
   'dist',
   'build',
   'storybook-static',
-  '.git',
+  '.git'
 ])
 
 /** Recursive story-file finder — `globToRegexp` from storybook internals
@@ -132,7 +134,7 @@ async function findStoryFiles(cwd: string, glob: string): Promise<string[]> {
           const rel = relative(cwd, abs).split(sep).join('/')
           if (pattern.test(rel)) out.push(abs)
         }
-      }),
+      })
     )
   }
 
@@ -166,78 +168,105 @@ async function main(): Promise<void> {
   const cwd = process.cwd()
   const configDir = resolve(cwd, args.configDir)
 
+  logger.intro(
+    `msw-storybook-addon migration${args.dryRun ? ' (dry run)' : ''}`
+  )
+
   const previewPath = args.preview
     ? resolve(cwd, args.preview)
     : findConfigFile(configDir, 'preview')
-  const mainPath = args.main ? resolve(cwd, args.main) : findConfigFile(configDir, 'main')
+  const mainPath = args.main
+    ? resolve(cwd, args.main)
+    : findConfigFile(configDir, 'main')
 
-  const migrateParameters = args.parameters ?? (await confirmParametersMigration())
+  const migrateParameters =
+    args.parameters ?? (await confirmParametersMigration())
 
-  let modified = 0
+  const transformed: string[] = []
+  const failed: string[] = []
   let unmodified = 0
-  let errors = 0
   const warnings: string[] = []
 
   let previewIsCsfNext: boolean | undefined
 
-  // -- Preview
+  const check = CLI_COLORS.success('✔')
+  // Flush the files transformed since the last phase as one block.
+  let flushedCount = 0
+  const flushPhase = () => {
+    const phaseFiles = transformed.slice(flushedCount).sort()
+    flushedCount = transformed.length
+    if (phaseFiles.length > 0) {
+      logger.log(phaseFiles.map((file) => `${check} ${file}`).join('\n'))
+    }
+  }
+
+  // -- Preview + main config
+  logger.step('Migrating your Storybook configuration...')
+
   if (previewPath && existsSync(previewPath)) {
     try {
       const source = await fs.readFile(previewPath, 'utf-8')
       const result = transformPreview(source, { migrateParameters })
       previewIsCsfNext = result.csfNext
-      for (const w of result.warnings) warnings.push(`  ${short(previewPath)}: ${w}`)
+      for (const w of result.warnings)
+        warnings.push(`${short(previewPath)}: ${w}`)
       if (result.code != null && result.code !== source) {
         if (!args.dryRun) {
-          await fs.writeFile(previewPath, await formatFileContent(previewPath, result.code), 'utf-8')
+          await fs.writeFile(
+            previewPath,
+            await formatFileContent(previewPath, result.code),
+            'utf-8'
+          )
         }
-        modified++
-        logger.log(`  ✓ ${short(previewPath)}`)
+        transformed.push(short(previewPath))
       } else {
         unmodified++
       }
     } catch (err) {
-      errors++
-      logger.error(`  ✗ ${short(previewPath)}: ${String(err)}`)
+      failed.push(`${short(previewPath)}: ${String(err)}`)
     }
   } else {
-    logger.warn(
-      `Preview file not found${args.preview ? `: ${args.preview}` : ` in ${short(configDir)}`}.`,
+    warnings.push(
+      `Preview file not found${args.preview ? `: ${args.preview}` : ` in ${short(configDir)}`}.`
     )
   }
 
-  // -- Main
   if (mainPath && existsSync(mainPath)) {
     try {
       const source = await fs.readFile(mainPath, 'utf-8')
       const out = transformMain(source)
       if (out != null && out !== source) {
         if (!args.dryRun) {
-          await fs.writeFile(mainPath, await formatFileContent(mainPath, out), 'utf-8')
+          await fs.writeFile(
+            mainPath,
+            await formatFileContent(mainPath, out),
+            'utf-8'
+          )
         }
-        modified++
-        logger.log(`  ✓ ${short(mainPath)}`)
+        transformed.push(short(mainPath))
       } else {
         unmodified++
       }
     } catch (err) {
-      errors++
-      logger.error(`  ✗ ${short(mainPath)}: ${String(err)}`)
+      failed.push(`${short(mainPath)}: ${String(err)}`)
     }
   } else {
-    logger.warn(
-      `Main config not found${args.main ? `: ${args.main}` : ` in ${short(configDir)}`}.`,
+    warnings.push(
+      `Main config not found${args.main ? `: ${args.main}` : ` in ${short(configDir)}`}.`
     )
   }
 
+  flushPhase()
+
   // -- Stories (opt-in)
   if (migrateParameters) {
+    logger.step('Migrating `parameters.msw` in your story files...')
     const limit = createLimiter(Math.max(1, os.cpus().length - 1))
 
     const storyFiles = await findStoryFiles(cwd, args.glob)
 
     if (storyFiles.length === 0) {
-      logger.warn(`No story files matched glob "${args.glob}".`)
+      warnings.push(`No story files matched glob "${args.glob}".`)
     }
 
     await Promise.all(
@@ -248,64 +277,90 @@ async function main(): Promise<void> {
             const result = transformStory(source)
             if (result.skippedStories.length > 0) {
               warnings.push(
-                `  ${short(file)}: ${result.skippedStories.join(', ')} — \`parameters.msw\` shape not recognised; hand-migrate.`,
+                `${short(file)}: ${result.skippedStories.join(', ')} — \`parameters.msw\` shape not recognised; hand-migrate.`
               )
             }
             if (result.code != null && result.code !== source) {
               if (!args.dryRun) {
-                await fs.writeFile(file, await formatFileContent(file, result.code), 'utf-8')
+                await fs.writeFile(
+                  file,
+                  await formatFileContent(file, result.code),
+                  'utf-8'
+                )
               }
-              modified++
-              logger.log(`  ✓ ${short(file)}`)
+              transformed.push(short(file))
             } else {
               unmodified++
             }
           } catch (err) {
-            errors++
-            logger.error(`  ✗ ${short(file)}: ${String(err)}`)
+            failed.push(`${short(file)}: ${String(err)}`)
           }
-        }),
-      ),
+        })
+      )
     )
   }
 
-  logger.log('')
+  flushPhase()
+
   logger.log(
-    `Summary: ${modified} transformed, ${unmodified} unmodified, ${errors} error(s)`,
+    CLI_COLORS.muted(
+      `${transformed.length} file(s) ${args.dryRun ? 'would be ' : ''}updated, ${unmodified} already up to date`
+    )
   )
 
-  if (warnings.length > 0) {
-    logger.log('')
-    logger.warn(`${warnings.length} thing(s) the codemod could not migrate:`)
-    for (const w of warnings) logger.log(w)
-    logger.log('  See MIGRATION.md in the msw-storybook-addon repository for hand-migration steps.')
+  if (failed.length > 0) {
+    logger.error(failed.join('\n'))
   }
 
-  logger.log('')
-  if (previewIsCsfNext === false) {
-    logger.log(
-      'This project uses CSF 3.0 — the migrated setup keeps working as-is. When you are ready, it is advisable to migrate to CSF Next:',
+  if (warnings.length > 0) {
+    logger.warn(
+      `The codemod could not migrate everything:\n${warnings.map((w) => `• ${w}`).join('\n')}\nSee the migration guide for the manual steps:\n${CLI_COLORS.cta(MIGRATION_URL)}`
     )
-    logger.log('  npx storybook automigrate csf-factories')
-    logger.log(
-      'Afterwards, run `npx msw-storybook-migrate` again — it replaces the loader wiring with `addonMsw()` and finishes the msw migration.',
+  }
+
+  if (previewIsCsfNext === false) {
+    logger.logBox(
+      dedent`
+        All set — your project keeps using CSF 3.0 and works as-is.
+
+        When you are ready, we recommend upgrading to CSF Next with:
+        ${CLI_COLORS.cta('npx storybook automigrate csf-factories')}
+
+        Then run ${CLI_COLORS.cta('npx msw-storybook-migrate')} once more and it will
+        move the addon to the new ${CLI_COLORS.cta('addonMsw()')} API for you.
+
+        To learn more about CSF Next, see the Storybook docs:
+        ${CLI_COLORS.cta('https://storybook.js.org/docs/api/csf/csf-next')}
+      `
     )
   } else if (previewIsCsfNext === true) {
-    logger.log(
-      'This project uses CSF Next — the msw addon is fully wired up via `addonMsw()`.',
+    logger.logBox(
+      dedent`
+        All set — your project uses CSF Next and the msw addon is
+        fully wired up via ${CLI_COLORS.cta('addonMsw()')}. Happy mocking!
+      `
     )
   } else {
-    logger.log(
-      'When you are ready to migrate to CSF Next, run `npx storybook automigrate csf-factories`, then run `npx msw-storybook-migrate` again to finish the msw migration.',
+    logger.logBox(
+      dedent`
+        When you are ready to upgrade to CSF Next, run:
+        ${CLI_COLORS.cta('npx storybook automigrate csf-factories')}
+
+        Then run ${CLI_COLORS.cta('npx msw-storybook-migrate')} once more to finish
+        the msw migration.
+      `
     )
   }
 
   if (args.dryRun) {
-    logger.log('')
-    logger.log('Dry run — re-run without --dry-run to apply.')
+    logger.outro(
+      'Dry run — nothing was written. Re-run without --dry-run to apply.'
+    )
+  } else {
+    logger.outro(failed.length > 0 ? 'Finished with errors.' : 'Done!')
   }
 
-  process.exit(errors > 0 ? 1 : 0)
+  process.exit(failed.length > 0 ? 1 : 0)
 }
 
 function short(p: string): string {

--- a/codemod/src/transforms/main.ts
+++ b/codemod/src/transforms/main.ts
@@ -1,0 +1,124 @@
+/**
+ * `.storybook/main.{js,ts}` transform.
+ *
+ * Single responsibility: ensure `'msw-storybook-addon'` is in the
+ * `addons` array of the exported Storybook config. The registration is
+ * what `npx storybook automigrate csf-factories` reads later to wire the
+ * addon into a CSF Next preview.
+ *
+ * Idempotent: if the entry already exists — as a bare string, a
+ * resolver-wrapped call (`getAbsolutePath('msw-storybook-addon')`), or
+ * the object form `{ name, options }` — the file isn't touched.
+ */
+
+import { types as t } from 'storybook/internal/babel'
+import {
+  type ConfigFile,
+  loadConfig,
+  printConfig
+} from 'storybook/internal/csf-tools'
+
+const ADDON_PACKAGE = 'msw-storybook-addon'
+
+export function transformMain(source: string): string | null {
+  let parsed: ConfigFile
+  try {
+    parsed = loadConfig(source).parse()
+  } catch {
+    return null
+  }
+
+  // The parser resolves plain objects, `defineMain({...})`-wrapped configs
+  // and variable-declared default exports alike.
+  if (!parsed._exportsObject) return null
+
+  const addonsNode = parsed.getFieldNode(['addons'])
+
+  if (!addonsNode) {
+    parsed.setFieldValue(['addons'], [ADDON_PACKAGE])
+    return printConfig(parsed).code
+  }
+
+  if (!t.isArrayExpression(addonsNode)) {
+    // `addons` exists but isn't an array literal (e.g. a spread of a
+    // shared list). Refuse rather than guess.
+    return null
+  }
+
+  if (alreadyHasAddon(addonsNode)) {
+    return null
+  }
+
+  // Follow the project's convention: pnpm setups commonly wrap addon
+  // entries in a resolver call — `addons: [getAbsolutePath('addon-name')]`.
+  // A plain string would not resolve there, so the new entry is wrapped
+  // with the same function.
+  const wrapper = detectWrapperName(addonsNode)
+  if (wrapper) {
+    parsed.appendNodeToArray(
+      ['addons'],
+      t.callExpression(t.identifier(wrapper), [
+        parsed.valueToNode(ADDON_PACKAGE) as t.Expression
+      ])
+    )
+  } else {
+    parsed.appendValueToArray(['addons'], ADDON_PACKAGE)
+  }
+  return printConfig(parsed).code
+}
+
+/** Unwrap an `addons` array entry to the addon package name it refers to.
+ *  Handles the bare string, the wrapped call (`getAbsolutePath('pkg')` or
+ *  any single-string-argument resolver), and the object form — with either
+ *  a string or a wrapped call as `name`. */
+function resolveAddonName(el: t.Node): string | null {
+  if (t.isStringLiteral(el)) return el.value
+  if (
+    t.isCallExpression(el) &&
+    t.isIdentifier(el.callee) &&
+    el.arguments.length === 1 &&
+    t.isStringLiteral(el.arguments[0])
+  ) {
+    return el.arguments[0].value
+  }
+  if (t.isObjectExpression(el)) {
+    const name = findProperty(el, 'name')
+    if (name) return resolveAddonName(name.value)
+  }
+  return null
+}
+
+function alreadyHasAddon(arr: t.ArrayExpression): boolean {
+  return arr.elements.some(
+    (el) => el != null && resolveAddonName(el) === ADDON_PACKAGE
+  )
+}
+
+/** The resolver function name used by existing entries, if any. */
+function detectWrapperName(arr: t.ArrayExpression): string | null {
+  for (const el of arr.elements) {
+    if (
+      el &&
+      t.isCallExpression(el) &&
+      t.isIdentifier(el.callee) &&
+      el.arguments.length === 1 &&
+      t.isStringLiteral(el.arguments[0])
+    ) {
+      return el.callee.name
+    }
+  }
+  return null
+}
+
+function findProperty(
+  obj: t.ObjectExpression,
+  name: string
+): t.ObjectProperty | undefined {
+  for (const prop of obj.properties) {
+    if (!t.isObjectProperty(prop)) continue
+    const key = prop.key
+    if (t.isIdentifier(key) && key.name === name) return prop
+    if (t.isStringLiteral(key) && key.value === name) return prop
+  }
+  return undefined
+}

--- a/codemod/src/transforms/preview.ts
+++ b/codemod/src/transforms/preview.ts
@@ -52,6 +52,7 @@ import {
 
 const ADDON_PACKAGE = 'msw-storybook-addon'
 const CSF3_SUBPATH = 'msw-storybook-addon/csf3'
+const PREVIEW_SUBPATH = 'msw-storybook-addon/preview'
 const MSW_BROWSER = 'msw/browser'
 
 export interface PreviewTransformOptions {
@@ -65,6 +66,10 @@ export interface PreviewTransformResult {
   code: string | null
   /** Human-readable reasons for anything the codemod refused to migrate. */
   warnings: string[]
+  /** Whether the preview uses CSF Next (`definePreview`). Undefined when
+   *  the file could not be parsed. The CLI uses this to tailor its
+   *  follow-up guidance. */
+  csfNext?: boolean
 }
 
 interface AddonImports {
@@ -76,6 +81,10 @@ interface AddonImports {
   mswDecorator?: string
   /** Local name of the default export (`addonMsw`), if imported. */
   addonDefault?: string
+  /** Local name of `import * as x from 'msw-storybook-addon/preview'` —
+   *  what `storybook automigrate csf-factories` injects into `addons`.
+   *  A no-op at runtime in v3, so it gets replaced with `addonMsw()`. */
+  previewNamespace?: string
 }
 
 interface InitializeFold {
@@ -112,7 +121,7 @@ export function transformPreview(
   if (imports.initialize) {
     const analyzed = analyzeInitialize(parsed, imports.initialize, warnings)
     if (analyzed === 'skip') {
-      return { code: null, warnings }
+      return { code: null, warnings, csfNext: isFactories }
     }
     fold = analyzed
   }
@@ -129,7 +138,7 @@ export function transformPreview(
         'Could not find the preview config object (the default export); hand-migrate this file.'
       )
     }
-    return { code: null, warnings }
+    return { code: null, warnings, csfNext: isFactories }
   }
 
   const needsSetup =
@@ -139,31 +148,56 @@ export function transformPreview(
 
   if (isFactories) {
     // ---- CSF Next -------------------------------------------------------
+    // A setup function carried by an existing `mswLoader(setup)` moves onto
+    // `addonMsw(setup)`. Collected before stripping the loader.
+    const loaderSetup = imports.mswLoader
+      ? collectLoaderSetup(previewObj, imports.mswLoader)
+      : null
+    if (loaderSetup === 'conflict') {
+      warnings.push(
+        'Multiple `mswLoader(...)` setup functions found; migrate this file by hand.'
+      )
+      return { code: null, warnings, csfNext: true }
+    }
+    if (needsSetup && loaderSetup != null) {
+      warnings.push(
+        'Both `initialize(...)` options and a `mswLoader(...)` setup function exist; merge them into one setup function by hand.'
+      )
+      return { code: null, warnings, csfNext: true }
+    }
+
     const strippedLoader = imports.mswLoader
       ? stripMswRef(previewObj, 'loaders', imports.mswLoader)
       : false
     const strippedDecorator = imports.mswDecorator
       ? stripMswRef(previewObj, 'decorators', imports.mswDecorator)
       : false
-    const hasWiring = strippedLoader || strippedDecorator || fold != null
+    const hasNamespaceEntry =
+      imports.previewNamespace != null &&
+      findAddonsEntryIndex(previewObj, imports.previewNamespace) !== -1
+    const hasWiring =
+      strippedLoader || strippedDecorator || hasNamespaceEntry || fold != null
 
     if (!hasWiring) {
       if (options.migrateParameters) {
         if (migratePreviewParameters(previewObj, warnings)) changed = true
       }
-      return finish(parsed, source, changed, warnings)
+      return finish(parsed, source, changed, warnings, true)
     }
 
     // Ensure the addon is registered, folding the setup function in.
+    const setupFn = needsSetup
+      ? buildSetupFunction(fold as InitializeFold)
+      : (loaderSetup as t.Expression | null)
     const addonResult = ensureFactoriesAddon(
       parsed,
       previewObj,
       imports,
-      needsSetup ? buildSetupFunction(fold as InitializeFold) : null,
+      setupFn,
       warnings
     )
     if (addonResult === 'conflict') {
-      return { code: null, warnings }
+      return { code: null, warnings, csfNext: true }
     }
     changed = true
 
@@ -171,6 +205,7 @@ export function transformPreview(
       removeStatement(body, fold.stmt)
     }
     removeSpecifiers(parsed, ['initialize', 'mswLoader', 'mswDecorator'])
+    if (hasNamespaceEntry) removePreviewNamespaceImport(parsed)
     if (needsSetup) ensureSetupWorkerImport(parsed)
   } else {
     // ---- CSF 3.0 --------------------------------------------------------
@@ -183,7 +218,7 @@ export function transformPreview(
       if (options.migrateParameters) {
         if (migratePreviewParameters(previewObj, warnings)) changed = true
       }
-      return finish(parsed, source, changed, warnings)
+      return finish(parsed, source, changed, warnings, false)
     }
 
     const loaderName = imports.mswLoader ?? 'mswLoader'
@@ -201,7 +236,7 @@ export function transformPreview(
       warnings.push(
         '`initialize(...)` options could not be folded: the existing `mswLoader(...)` already receives a setup function. Merge them by hand.'
       )
-      return { code: null, warnings }
+      return { code: null, warnings, csfNext: false }
     }
     if (loaderResult === 'changed') changed = true
 
@@ -225,18 +260,19 @@ export function transformPreview(
     if (migratePreviewParameters(previewObj, warnings)) changed = true
   }
 
-  return finish(parsed, source, changed, warnings)
+  return finish(parsed, source, changed, warnings, isFactories)
 }
 
 function finish(
   parsed: ConfigFile,
   source: string,
   changed: boolean,
-  warnings: string[]
+  warnings: string[],
+  csfNext: boolean
 ): PreviewTransformResult {
-  if (!changed) return { code: null, warnings }
+  if (!changed) return { code: null, warnings, csfNext }
   const code = printConfig(parsed).code
-  return { code: code === source ? null : code, warnings }
+  return { code: code === source ? null : code, warnings, csfNext }
 }
 
 // -------- imports
@@ -246,6 +282,14 @@ function collectAddonImports(body: t.Statement[]): AddonImports {
   for (const stmt of body) {
     if (!t.isImportDeclaration(stmt)) continue
     const src = stmt.source.value
+    if (src === PREVIEW_SUBPATH) {
+      for (const spec of stmt.specifiers) {
+        if (t.isImportNamespaceSpecifier(spec)) {
+          out.previewNamespace = spec.local.name
+        }
+      }
+      continue
+    }
     if (src !== ADDON_PACKAGE && src !== CSF3_SUBPATH) continue
     for (const spec of stmt.specifiers) {
       if (t.isImportDefaultSpecifier(spec)) {
@@ -686,7 +730,7 @@ function ensureFactoriesAddon(
   parsed: ConfigFile,
   configObj: t.ObjectExpression,
   imports: AddonImports,
-  setupFn: t.ArrowFunctionExpression | null,
+  setupFn: t.Expression | null,
   warnings: string[]
 ): AddonOutcome {
   let localName = imports.addonDefault
@@ -696,6 +740,16 @@ function ensureFactoriesAddon(
     addonsProp && t.isArrayExpression(addonsProp.value)
       ? addonsProp.value
       : null
+
+  const removeNamespaceEntry = (): boolean => {
+    if (!imports.previewNamespace || !addonsArray) return false
+    const before = addonsArray.elements.length
+    addonsArray.elements = addonsArray.elements.filter(
+      (el) =>
+        !(el != null && t.isIdentifier(el) && el.name === imports.previewNamespace)
+    )
+    return addonsArray.elements.length !== before
+  }
 
   // Look for an existing registration first (conflict detection must run
   // before any mutation).
@@ -711,17 +765,19 @@ function ensureFactoriesAddon(
       if (setupFn) {
         if (isCall && (el as t.CallExpression).arguments.length > 0) {
           warnings.push(
-            '`initialize(...)` options could not be folded: the existing `addonMsw(...)` already receives a setup function. Merge them by hand.'
+            'A setup function could not be folded: the existing `addonMsw(...)` already receives one. Merge them by hand.'
           )
           return 'conflict'
         }
         if (isCall) {
           ;(el as t.CallExpression).arguments.push(setupFn)
+          removeNamespaceEntry()
           return 'changed'
         }
       }
-      // Registered and nothing to fold — done.
-      return 'unchanged'
+      // Registered and nothing to fold — done, but a leftover injected
+      // namespace entry still gets cleaned up.
+      return removeNamespaceEntry() ? 'changed' : 'unchanged'
     }
   }
 
@@ -751,6 +807,19 @@ function ensureFactoriesAddon(
     setupFn ? [setupFn] : []
   )
 
+  // The namespace entry injected by `storybook automigrate csf-factories`
+  // (`addons: [mswStorybookAddon]`) is replaced in place.
+  if (imports.previewNamespace && addonsArray) {
+    const nsIndex = addonsArray.elements.findIndex(
+      (el) =>
+        el != null && t.isIdentifier(el) && el.name === imports.previewNamespace
+    )
+    if (nsIndex !== -1) {
+      addonsArray.elements[nsIndex] = call
+      return 'changed'
+    }
+  }
+
   if (!addonsProp) {
     configObj.properties.unshift(
       t.objectProperty(t.identifier('addons'), t.arrayExpression([call]))
@@ -765,6 +834,60 @@ function ensureFactoriesAddon(
   }
   addonsArray.elements.unshift(call)
   return 'changed'
+}
+
+/** Setup function carried by `mswLoader(setup)` entries in `loaders`. */
+function collectLoaderSetup(
+  previewObj: t.ObjectExpression,
+  loaderName: string
+): t.Expression | null | 'conflict' {
+  const prop = findObjectProperty(previewObj, 'loaders')
+  if (!prop) return null
+
+  const calls: t.CallExpression[] = []
+  const consider = (el: t.Node | null | undefined) => {
+    if (
+      el != null &&
+      t.isCallExpression(el) &&
+      t.isIdentifier(el.callee) &&
+      el.callee.name === loaderName &&
+      el.arguments.length > 0
+    ) {
+      calls.push(el)
+    }
+  }
+  if (t.isArrayExpression(prop.value)) {
+    for (const el of prop.value.elements) consider(el)
+  } else {
+    consider(prop.value)
+  }
+
+  if (calls.length === 0) return null
+  if (calls.length > 1 || calls[0].arguments.length > 1) return 'conflict'
+  const arg = calls[0].arguments[0]
+  return t.isExpression(arg) ? arg : 'conflict'
+}
+
+/** Index of a bare-identifier entry in `addons: [...]`, or -1. */
+function findAddonsEntryIndex(
+  previewObj: t.ObjectExpression,
+  name: string
+): number {
+  const prop = findObjectProperty(previewObj, 'addons')
+  if (!prop || !t.isArrayExpression(prop.value)) return -1
+  return prop.value.elements.findIndex(
+    (el) => el != null && t.isIdentifier(el) && el.name === name
+  )
+}
+
+/** Drop `import * as x from 'msw-storybook-addon/preview'` once its
+ *  `addons` entry has been replaced. */
+function removePreviewNamespaceImport(parsed: ConfigFile): void {
+  parsed._ast.program.body = parsed._ast.program.body.filter((stmt) => {
+    if (!t.isImportDeclaration(stmt)) return true
+    if (stmt.source.value !== PREVIEW_SUBPATH) return true
+    return !stmt.specifiers.some((s) => t.isImportNamespaceSpecifier(s))
+  })
 }
 
 // -------- opt-in: preview-level `parameters.msw` → `beforeEach`

--- a/codemod/src/transforms/preview.ts
+++ b/codemod/src/transforms/preview.ts
@@ -135,7 +135,7 @@ export function transformPreview(
   if (!previewObj) {
     if (usesMsw) {
       warnings.push(
-        'Could not find the preview config object (the default export); hand-migrate this file.'
+        'Could not find the preview config object (the default export); you will need to migrate this file yourself.'
       )
     }
     return { code: null, warnings, csfNext: isFactories }
@@ -155,13 +155,13 @@ export function transformPreview(
       : null
     if (loaderSetup === 'conflict') {
       warnings.push(
-        'Multiple `mswLoader(...)` setup functions found; migrate this file by hand.'
+        'Multiple `mswLoader(...)` setup functions found; you will need to migrate this file yourself.'
       )
       return { code: null, warnings, csfNext: true }
     }
     if (needsSetup && loaderSetup != null) {
       warnings.push(
-        'Both `initialize(...)` options and a `mswLoader(...)` setup function exist; merge them into one setup function by hand.'
+        'Both `initialize(...)` options and a `mswLoader(...)` setup function exist; you will need to merge them into one setup function yourself.'
       )
       return { code: null, warnings, csfNext: true }
     }
@@ -234,7 +234,7 @@ export function transformPreview(
     )
     if (loaderResult === 'conflict') {
       warnings.push(
-        '`initialize(...)` options could not be folded: the existing `mswLoader(...)` already receives a setup function. Merge them by hand.'
+        '`initialize(...)` options could not be folded: the existing `mswLoader(...)` already receives a setup function. You will need to merge them yourself.'
       )
       return { code: null, warnings, csfNext: false }
     }
@@ -477,7 +477,7 @@ function analyzeInitialize(
     countIdentifierReferences(parsed._ast.program, localName, knownNodes) > 0
   ) {
     warnings.push(
-      `\`${localName}\` is used in a way the codemod cannot rewrite (e.g. its return value is captured, or it is called conditionally). Migrate this file by hand — see the "initialize is removed" section of MIGRATION.md.`
+      `\`${localName}\` is used in a way the codemod cannot rewrite (e.g. its return value is captured, or it is called conditionally). You will need to migrate this file yourself — see the "initialize is removed" section of the migration guide.`
     )
     return 'skip'
   }
@@ -489,7 +489,7 @@ function analyzeInitialize(
 
   if (calls.length > 1) {
     warnings.push(
-      `Multiple \`${localName}(...)\` calls found; migrate this file by hand.`
+      `Multiple \`${localName}(...)\` calls found; you will need to migrate this file yourself.`
     )
     return 'skip'
   }
@@ -499,13 +499,13 @@ function analyzeInitialize(
 
   if (args.some((a) => !t.isExpression(a))) {
     warnings.push(
-      `\`${localName}(...)\` receives arguments the codemod cannot carry over (e.g. spreads); migrate this file by hand.`
+      `\`${localName}(...)\` receives arguments the codemod cannot carry over (e.g. spreads); you will need to migrate this file yourself.`
     )
     return 'skip'
   }
   if (args.length > 2) {
     warnings.push(
-      `\`${localName}(...)\` receives more than two arguments; migrate this file by hand.`
+      `\`${localName}(...)\` receives more than two arguments; you will need to migrate this file yourself.`
     )
     return 'skip'
   }
@@ -765,7 +765,7 @@ function ensureFactoriesAddon(
       if (setupFn) {
         if (isCall && (el as t.CallExpression).arguments.length > 0) {
           warnings.push(
-            'A setup function could not be folded: the existing `addonMsw(...)` already receives one. Merge them by hand.'
+            'A setup function could not be folded: the existing `addonMsw(...)` already receives one. You will need to merge them yourself.'
           )
           return 'conflict'
         }
@@ -828,7 +828,7 @@ function ensureFactoriesAddon(
   }
   if (!addonsArray) {
     warnings.push(
-      '`addons` in definePreview is not an array literal; register `addonMsw()` by hand.'
+      '`addons` in definePreview is not an array literal; you will need to register `addonMsw()` yourself.'
     )
     return 'conflict'
   }
@@ -906,14 +906,14 @@ function migratePreviewParameters(
   const handlers = extractHandlers(mswProp.value)
   if (!handlers) {
     warnings.push(
-      'Preview-level `parameters.msw` has a shape the codemod does not recognise; migrate it to `beforeEach({ msw })` by hand.'
+      'Preview-level `parameters.msw` has a shape the codemod does not recognize; you will need to migrate it to `beforeEach({ msw })` yourself.'
     )
     return false
   }
 
   if (handlers.length > 0 && hasAnyProperty(previewObj, 'beforeEach')) {
     warnings.push(
-      'The preview already defines `beforeEach`; merge the `parameters.msw` handlers into it by hand.'
+      'The preview already defines `beforeEach`; you will need to move the `parameters.msw` handlers into it yourself.'
     )
     return false
   }

--- a/codemod/src/transforms/preview.ts
+++ b/codemod/src/transforms/preview.ts
@@ -1,0 +1,819 @@
+/**
+ * `.storybook/preview.{js,ts,jsx,tsx}` transform.
+ *
+ * Migrates a v2 preview to the v3 wiring:
+ *
+ *   CSF 3.0 (plain-object preview):
+ *     - `loaders: [mswLoader]` / `loaders: mswLoader` → `loaders: [mswLoader()]`
+ *     - `decorators: [mswDecorator]` → removed; a `mswLoader()` loader is
+ *       ensured instead (the 2.x migration documented them as equivalent).
+ *     - `initialize()` (bare) → removed.
+ *     - `initialize(options[, initialHandlers])` → removed; folded into a
+ *       setup function passed to `mswLoader(async () => { ... })`.
+ *     - `import { mswLoader } from 'msw-storybook-addon'` → retargeted to
+ *       the `msw-storybook-addon/csf3` subpath.
+ *
+ *   CSF Next (`definePreview({...})`):
+ *     - Any leftover v2/v3 wiring (loaders, decorators, `initialize`) is
+ *       stripped and `addonMsw()` is ensured in `addons: [...]`, with
+ *       `initialize` options folded into `addonMsw(setup)`.
+ *     - A file with no msw wiring at all is left untouched.
+ *
+ *   Opt-in (`migrateParameters`): preview-level `parameters.msw` is
+ *   converted into a `beforeEach({ msw })` hook using the same
+ *   recognised-shapes-only rules as the story transform.
+ *
+ * Skip-and-warn (the file is left untouched and a warning is returned):
+ *     - `const worker = initialize(...)` — the return value is captured;
+ *       v3 has no synchronous worker reference to give back.
+ *     - `initialize` referenced anywhere other than a plain top-level call
+ *       (conditional calls, re-exports, passing it around).
+ *     - More than one `initialize(...)` call.
+ *     - `initialize(...args)` spread arguments.
+ *     - `initialize` options to fold, but the existing `mswLoader(...)` /
+ *       `addonMsw(...)` already carries a setup function.
+ *
+ * Idempotent: running twice produces the same result and no spurious diff.
+ */
+
+import { types as t } from 'storybook/internal/babel'
+import {
+  type ConfigFile,
+  isCsfFactoryPreview,
+  loadConfig,
+  printConfig
+} from 'storybook/internal/csf-tools'
+import {
+  buildBeforeEachProperty,
+  extractHandlers,
+  findObjectProperty,
+  hasAnyProperty
+} from './stories'
+
+const ADDON_PACKAGE = 'msw-storybook-addon'
+const CSF3_SUBPATH = 'msw-storybook-addon/csf3'
+const MSW_BROWSER = 'msw/browser'
+
+export interface PreviewTransformOptions {
+  /** Also migrate preview-level `parameters.msw` to `beforeEach({ msw })`. */
+  migrateParameters?: boolean
+}
+
+export interface PreviewTransformResult {
+  /** Transformed source, or null when no changes were needed (or the file
+   *  was skipped — check `warnings`). */
+  code: string | null
+  /** Human-readable reasons for anything the codemod refused to migrate. */
+  warnings: string[]
+}
+
+interface AddonImports {
+  /** Local name of `initialize`, if imported. */
+  initialize?: string
+  /** Local name of `mswLoader`, if imported (from the root or /csf3). */
+  mswLoader?: string
+  /** Local name of `mswDecorator`, if imported. */
+  mswDecorator?: string
+  /** Local name of the default export (`addonMsw`), if imported. */
+  addonDefault?: string
+}
+
+interface InitializeFold {
+  /** The top-level `initialize(...)` statement to remove. */
+  stmt: t.ExpressionStatement
+  /** `worker.start()` options — first argument, carried verbatim. */
+  options?: t.Expression
+  /** Initial handlers — second argument, spread into `setupWorker(...)`. */
+  handlers?: t.Expression
+}
+
+export function transformPreview(
+  source: string,
+  options: PreviewTransformOptions = {}
+): PreviewTransformResult {
+  const warnings: string[] = []
+  let parsed: ConfigFile
+  try {
+    parsed = loadConfig(source).parse()
+  } catch {
+    return { code: null, warnings }
+  }
+
+  const body = parsed._ast.program.body
+  const imports = collectAddonImports(body)
+  // The parser unwraps call-wrapped and variable-declared default exports,
+  // so this covers `export default {}`, `export default definePreview({})`
+  // and `const preview = definePreview({}); export default preview`.
+  const previewObj = parsed._exportsObject ?? null
+  const isFactories = isCsfFactoryPreview(parsed)
+
+  // ---- analyze `initialize` usage (before mutating anything) ----
+  let fold: InitializeFold | null = null
+  if (imports.initialize) {
+    const analyzed = analyzeInitialize(parsed, imports.initialize, warnings)
+    if (analyzed === 'skip') {
+      return { code: null, warnings }
+    }
+    fold = analyzed
+  }
+
+  const usesMsw =
+    imports.initialize != null ||
+    imports.mswLoader != null ||
+    imports.mswDecorator != null ||
+    imports.addonDefault != null
+
+  if (!previewObj) {
+    if (usesMsw) {
+      warnings.push(
+        'Could not find the preview config object (the default export); hand-migrate this file.'
+      )
+    }
+    return { code: null, warnings }
+  }
+
+  const needsSetup =
+    fold != null && (fold.options != null || fold.handlers != null)
+
+  let changed = false
+
+  if (isFactories) {
+    // ---- CSF Next -------------------------------------------------------
+    const strippedLoader = imports.mswLoader
+      ? stripMswRef(previewObj, 'loaders', imports.mswLoader)
+      : false
+    const strippedDecorator = imports.mswDecorator
+      ? stripMswRef(previewObj, 'decorators', imports.mswDecorator)
+      : false
+    const hasWiring = strippedLoader || strippedDecorator || fold != null
+
+    if (!hasWiring) {
+      if (options.migrateParameters) {
+        if (migratePreviewParameters(previewObj, warnings)) changed = true
+      }
+      return finish(parsed, source, changed, warnings)
+    }
+
+    // Ensure the addon is registered, folding the setup function in.
+    const addonResult = ensureFactoriesAddon(
+      parsed,
+      previewObj,
+      imports,
+      needsSetup ? buildSetupFunction(fold as InitializeFold) : null,
+      warnings
+    )
+    if (addonResult === 'conflict') {
+      return { code: null, warnings }
+    }
+    changed = true
+
+    if (fold != null) {
+      removeStatement(body, fold.stmt)
+    }
+    removeSpecifiers(parsed, ['initialize', 'mswLoader', 'mswDecorator'])
+    if (needsSetup) ensureSetupWorkerImport(parsed)
+  } else {
+    // ---- CSF 3.0 --------------------------------------------------------
+    // Only wire the loader when the file actually used the loader path
+    // (loader, decorator, or initialize) — a stray default import alone is
+    // not enough to justify injecting wiring.
+    const usesLoaderPath =
+      imports.mswLoader != null || imports.mswDecorator != null || fold != null
+    if (!usesLoaderPath) {
+      if (options.migrateParameters) {
+        if (migratePreviewParameters(previewObj, warnings)) changed = true
+      }
+      return finish(parsed, source, changed, warnings)
+    }
+
+    const loaderName = imports.mswLoader ?? 'mswLoader'
+    const setupFn = needsSetup
+      ? buildSetupFunction(fold as InitializeFold)
+      : null
+
+    const loaderResult = ensureLoaderCall(
+      previewObj,
+      loaderName,
+      setupFn,
+      imports
+    )
+    if (loaderResult === 'conflict') {
+      warnings.push(
+        '`initialize(...)` options could not be folded: the existing `mswLoader(...)` already receives a setup function. Merge them by hand.'
+      )
+      return { code: null, warnings }
+    }
+    if (loaderResult === 'changed') changed = true
+
+    if (imports.mswDecorator) {
+      if (stripMswRef(previewObj, 'decorators', imports.mswDecorator))
+        changed = true
+    }
+
+    if (fold != null) {
+      removeStatement(body, fold.stmt)
+      changed = true
+    }
+
+    if (removeSpecifiers(parsed, ['initialize', 'mswDecorator'])) changed = true
+    if (retargetLoaderImport(parsed)) changed = true
+    if (ensureLoaderImport(parsed, loaderName)) changed = true
+    if (needsSetup) ensureSetupWorkerImport(parsed)
+  }
+
+  if (options.migrateParameters) {
+    if (migratePreviewParameters(previewObj, warnings)) changed = true
+  }
+
+  return finish(parsed, source, changed, warnings)
+}
+
+function finish(
+  parsed: ConfigFile,
+  source: string,
+  changed: boolean,
+  warnings: string[]
+): PreviewTransformResult {
+  if (!changed) return { code: null, warnings }
+  const code = printConfig(parsed).code
+  return { code: code === source ? null : code, warnings }
+}
+
+// -------- imports
+
+function collectAddonImports(body: t.Statement[]): AddonImports {
+  const out: AddonImports = {}
+  for (const stmt of body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    const src = stmt.source.value
+    if (src !== ADDON_PACKAGE && src !== CSF3_SUBPATH) continue
+    for (const spec of stmt.specifiers) {
+      if (t.isImportDefaultSpecifier(spec)) {
+        out.addonDefault = spec.local.name
+      } else if (t.isImportSpecifier(spec)) {
+        const name = importedName(spec)
+        if (name === 'initialize') out.initialize = spec.local.name
+        if (name === 'mswLoader') out.mswLoader = spec.local.name
+        if (name === 'mswDecorator') out.mswDecorator = spec.local.name
+      }
+    }
+  }
+  return out
+}
+
+function importedName(spec: t.ImportSpecifier): string | null {
+  const imported = spec.imported
+  return (
+    (t.isIdentifier(imported) && imported.name) ||
+    (t.isStringLiteral(imported) && imported.value) ||
+    null
+  )
+}
+
+/** Remove the given specifiers from addon imports; drop emptied declarations. */
+function removeSpecifiers(parsed: ConfigFile, names: string[]): boolean {
+  let changed = false
+  const body = parsed._ast.program.body
+  for (const stmt of body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    const src = stmt.source.value
+    if (src !== ADDON_PACKAGE && src !== CSF3_SUBPATH) continue
+    const before = stmt.specifiers.length
+    stmt.specifiers = stmt.specifiers.filter((spec) => {
+      if (!t.isImportSpecifier(spec)) return true
+      const name = importedName(spec)
+      return name == null || !names.includes(name)
+    })
+    if (stmt.specifiers.length !== before) changed = true
+  }
+  parsed._ast.program.body = body.filter((stmt) => {
+    if (!t.isImportDeclaration(stmt)) return true
+    const src = stmt.source.value
+    if (src !== ADDON_PACKAGE && src !== CSF3_SUBPATH) return true
+    // Preserve genuine side-effect imports (they never had specifiers we
+    // could have removed); drop declarations we emptied ourselves.
+    return stmt.specifiers.length > 0
+  })
+  return changed
+}
+
+/** Move a root-package `mswLoader` specifier onto the /csf3 subpath. */
+function retargetLoaderImport(parsed: ConfigFile): boolean {
+  const body = parsed._ast.program.body
+  let loaderSpec: t.ImportSpecifier | null = null
+  let changed = false
+
+  for (const stmt of body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    if (stmt.source.value !== ADDON_PACKAGE) continue
+    const spec = stmt.specifiers.find(
+      (s): s is t.ImportSpecifier =>
+        t.isImportSpecifier(s) && importedName(s) === 'mswLoader'
+    )
+    if (!spec) continue
+
+    const onlySpecifier = stmt.specifiers.length === 1
+    if (onlySpecifier) {
+      stmt.source = t.stringLiteral(CSF3_SUBPATH)
+    } else {
+      stmt.specifiers = stmt.specifiers.filter((s) => s !== spec)
+      loaderSpec = spec
+    }
+    changed = true
+  }
+
+  if (loaderSpec) {
+    mergeIntoCsf3Import(parsed, loaderSpec)
+  }
+  return changed
+}
+
+function mergeIntoCsf3Import(
+  parsed: ConfigFile,
+  spec: t.ImportSpecifier
+): void {
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    if (stmt.source.value !== CSF3_SUBPATH) continue
+    const has = stmt.specifiers.some(
+      (s) => t.isImportSpecifier(s) && importedName(s) === importedName(spec)
+    )
+    if (!has) stmt.specifiers.push(spec)
+    return
+  }
+  parsed._ast.program.body.unshift(
+    t.importDeclaration([spec], t.stringLiteral(CSF3_SUBPATH))
+  )
+}
+
+/** Ensure `import { mswLoader } from 'msw-storybook-addon/csf3'` exists. */
+function ensureLoaderImport(parsed: ConfigFile, localName: string): boolean {
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    if (stmt.source.value !== CSF3_SUBPATH) continue
+    const has = stmt.specifiers.some(
+      (s) => t.isImportSpecifier(s) && importedName(s) === 'mswLoader'
+    )
+    if (has) return false
+    stmt.specifiers.push(
+      t.importSpecifier(t.identifier(localName), t.identifier('mswLoader'))
+    )
+    return true
+  }
+  parsed._ast.program.body.unshift(
+    t.importDeclaration(
+      [t.importSpecifier(t.identifier(localName), t.identifier('mswLoader'))],
+      t.stringLiteral(CSF3_SUBPATH)
+    )
+  )
+  return true
+}
+
+/** Ensure `import { setupWorker } from 'msw/browser'` exists. */
+function ensureSetupWorkerImport(parsed: ConfigFile): void {
+  for (const stmt of parsed._ast.program.body) {
+    if (!t.isImportDeclaration(stmt)) continue
+    if (stmt.source.value !== MSW_BROWSER) continue
+    const has = stmt.specifiers.some(
+      (s) => t.isImportSpecifier(s) && importedName(s) === 'setupWorker'
+    )
+    if (!has) {
+      stmt.specifiers.push(
+        t.importSpecifier(
+          t.identifier('setupWorker'),
+          t.identifier('setupWorker')
+        )
+      )
+    }
+    return
+  }
+  parsed._ast.program.body.unshift(
+    t.importDeclaration(
+      [
+        t.importSpecifier(
+          t.identifier('setupWorker'),
+          t.identifier('setupWorker')
+        )
+      ],
+      t.stringLiteral(MSW_BROWSER)
+    )
+  )
+}
+
+// -------- `initialize` analysis
+
+function analyzeInitialize(
+  parsed: ConfigFile,
+  localName: string,
+  warnings: string[]
+): InitializeFold | null | 'skip' {
+  const body = parsed._ast.program.body
+  const calls: { stmt: t.ExpressionStatement; call: t.CallExpression }[] = []
+  const knownNodes = new Set<t.Node>()
+
+  for (const stmt of body) {
+    if (t.isImportDeclaration(stmt)) {
+      knownNodes.add(stmt)
+      continue
+    }
+    if (
+      t.isExpressionStatement(stmt) &&
+      t.isCallExpression(stmt.expression) &&
+      t.isIdentifier(stmt.expression.callee) &&
+      stmt.expression.callee.name === localName
+    ) {
+      calls.push({ stmt, call: stmt.expression })
+      knownNodes.add(stmt.expression.callee)
+    }
+  }
+
+  // Any other reference to `initialize` (captured return value, conditional
+  // call, passing the function around) → we can't rewrite faithfully.
+  if (
+    countIdentifierReferences(parsed._ast.program, localName, knownNodes) > 0
+  ) {
+    warnings.push(
+      `\`${localName}\` is used in a way the codemod cannot rewrite (e.g. its return value is captured, or it is called conditionally). Migrate this file by hand — see the "initialize is removed" section of MIGRATION.md.`
+    )
+    return 'skip'
+  }
+
+  if (calls.length === 0) {
+    // Imported but never called — just drop the import.
+    return null
+  }
+
+  if (calls.length > 1) {
+    warnings.push(
+      `Multiple \`${localName}(...)\` calls found; migrate this file by hand.`
+    )
+    return 'skip'
+  }
+
+  const { stmt, call } = calls[0]
+  const args = call.arguments
+
+  if (args.some((a) => !t.isExpression(a))) {
+    warnings.push(
+      `\`${localName}(...)\` receives arguments the codemod cannot carry over (e.g. spreads); migrate this file by hand.`
+    )
+    return 'skip'
+  }
+  if (args.length > 2) {
+    warnings.push(
+      `\`${localName}(...)\` receives more than two arguments; migrate this file by hand.`
+    )
+    return 'skip'
+  }
+
+  return {
+    stmt,
+    options: (args[0] as t.Expression | undefined) ?? undefined,
+    handlers: (args[1] as t.Expression | undefined) ?? undefined
+  }
+}
+
+/** Count `Identifier` references to `name`, ignoring the given nodes and
+ *  non-reference positions we can cheaply detect (member properties and
+ *  non-computed object keys). Conservative: an unexplained occurrence makes
+ *  the caller skip the file. */
+function countIdentifierReferences(
+  root: t.Node,
+  name: string,
+  ignore: Set<t.Node>
+): number {
+  let count = 0
+  const seen = new Set<t.Node>()
+
+  function walk(node: t.Node | null | undefined): void {
+    if (node == null || typeof node !== 'object' || seen.has(node)) return
+    seen.add(node)
+    if (ignore.has(node)) return
+
+    if (t.isIdentifier(node) && node.name === name) {
+      count++
+      return
+    }
+
+    for (const key of Object.keys(node)) {
+      if (
+        key === 'loc' ||
+        key === 'leadingComments' ||
+        key === 'trailingComments' ||
+        key === 'innerComments'
+      ) {
+        continue
+      }
+      // Skip non-reference identifier positions.
+      if (t.isMemberExpression(node) && key === 'property' && !node.computed)
+        continue
+      if (
+        (t.isObjectProperty(node) || t.isObjectMethod(node)) &&
+        key === 'key' &&
+        !node.computed
+      )
+        continue
+
+      const value = (node as unknown as Record<string, unknown>)[key]
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (item && typeof item === 'object' && 'type' in item)
+            walk(item as t.Node)
+        }
+      } else if (value && typeof value === 'object' && 'type' in value) {
+        walk(value as t.Node)
+      }
+    }
+  }
+
+  walk(root)
+  return count
+}
+
+// -------- setup function builder
+//
+//   async () => {
+//     const worker = setupWorker(...initialHandlers)
+//     await worker.start(options)
+//     return worker
+//   }
+
+function buildSetupFunction(fold: InitializeFold): t.ArrowFunctionExpression {
+  const setupWorkerArgs: (t.Expression | t.SpreadElement)[] = []
+  if (fold.handlers) {
+    if (t.isArrayExpression(fold.handlers)) {
+      for (const el of fold.handlers.elements) {
+        if (el != null)
+          setupWorkerArgs.push(el as t.Expression | t.SpreadElement)
+      }
+    } else {
+      setupWorkerArgs.push(t.spreadElement(fold.handlers))
+    }
+  }
+
+  const startArgs: t.Expression[] = fold.options ? [fold.options] : []
+
+  const bodyStatements: t.Statement[] = [
+    t.variableDeclaration('const', [
+      t.variableDeclarator(
+        t.identifier('worker'),
+        t.callExpression(t.identifier('setupWorker'), setupWorkerArgs)
+      )
+    ]),
+    t.expressionStatement(
+      t.awaitExpression(
+        t.callExpression(
+          t.memberExpression(t.identifier('worker'), t.identifier('start')),
+          startArgs
+        )
+      )
+    ),
+    t.returnStatement(t.identifier('worker'))
+  ]
+
+  const fn = t.arrowFunctionExpression([], t.blockStatement(bodyStatements))
+  fn.async = true
+  return fn
+}
+
+// -------- CSF 3.0: ensure `loaders: [mswLoader(...)]`
+
+type LoaderOutcome = 'changed' | 'unchanged' | 'conflict'
+
+function ensureLoaderCall(
+  previewObj: t.ObjectExpression,
+  loaderName: string,
+  setupFn: t.ArrowFunctionExpression | null,
+  imports: AddonImports
+): LoaderOutcome {
+  const makeCall = () =>
+    t.callExpression(t.identifier(loaderName), setupFn ? [setupFn] : [])
+
+  const loadersProp = findObjectProperty(previewObj, 'loaders')
+
+  if (!loadersProp) {
+    // No loaders at all. Only wire the loader in when the file used the
+    // addon (decorator or initialize) — which callers guarantee.
+    previewObj.properties.unshift(
+      t.objectProperty(t.identifier('loaders'), t.arrayExpression([makeCall()]))
+    )
+    return 'changed'
+  }
+
+  const value = loadersProp.value
+
+  // `loaders: mswLoader` shorthand → `loaders: [mswLoader(...)]`
+  if (
+    t.isIdentifier(value) &&
+    value.name === (imports.mswLoader ?? loaderName)
+  ) {
+    loadersProp.value = t.arrayExpression([makeCall()])
+    return 'changed'
+  }
+
+  if (!t.isArrayExpression(value)) return 'unchanged'
+
+  for (let i = 0; i < value.elements.length; i++) {
+    const el = value.elements[i]
+    if (el == null) continue
+    // Bare reference: `loaders: [mswLoader]`
+    if (t.isIdentifier(el) && el.name === (imports.mswLoader ?? loaderName)) {
+      value.elements[i] = makeCall()
+      return 'changed'
+    }
+    // Already a call: `loaders: [mswLoader()]`
+    if (
+      t.isCallExpression(el) &&
+      t.isIdentifier(el.callee) &&
+      el.callee.name === (imports.mswLoader ?? loaderName)
+    ) {
+      if (setupFn) {
+        if (el.arguments.length > 0) return 'conflict'
+        el.arguments.push(setupFn)
+        return 'changed'
+      }
+      return 'unchanged'
+    }
+  }
+
+  // Loaders array exists but has no msw entry — add one.
+  value.elements.push(makeCall())
+  return 'changed'
+}
+
+// -------- drop `mswLoader`/`mswDecorator` references
+
+function stripMswRef(
+  obj: t.ObjectExpression,
+  propName: string,
+  refName: string
+): boolean {
+  const prop = findObjectProperty(obj, propName)
+  if (!prop) return false
+  const value = prop.value
+
+  if (t.isIdentifier(value) && value.name === refName) {
+    obj.properties = obj.properties.filter((p) => p !== prop)
+    return true
+  }
+  if (t.isArrayExpression(value)) {
+    const before = value.elements.length
+    value.elements = value.elements.filter((el) => {
+      if (el == null) return true
+      if (t.isIdentifier(el) && el.name === refName) return false
+      if (
+        t.isCallExpression(el) &&
+        t.isIdentifier(el.callee) &&
+        el.callee.name === refName
+      )
+        return false
+      return true
+    })
+    if (value.elements.length === 0 && before > 0) {
+      obj.properties = obj.properties.filter((p) => p !== prop)
+      return true
+    }
+    return value.elements.length !== before
+  }
+  return false
+}
+
+// -------- CSF Next: ensure `addonMsw(...)` in `addons: [...]`
+
+type AddonOutcome = 'changed' | 'unchanged' | 'conflict'
+
+function ensureFactoriesAddon(
+  parsed: ConfigFile,
+  configObj: t.ObjectExpression,
+  imports: AddonImports,
+  setupFn: t.ArrowFunctionExpression | null,
+  warnings: string[]
+): AddonOutcome {
+  let localName = imports.addonDefault
+
+  const addonsProp = findObjectProperty(configObj, 'addons')
+  const addonsArray =
+    addonsProp && t.isArrayExpression(addonsProp.value)
+      ? addonsProp.value
+      : null
+
+  // Look for an existing registration first (conflict detection must run
+  // before any mutation).
+  if (localName && addonsArray) {
+    for (const el of addonsArray.elements) {
+      if (el == null) continue
+      const isBare = t.isIdentifier(el) && el.name === localName
+      const isCall =
+        t.isCallExpression(el) &&
+        t.isIdentifier(el.callee) &&
+        el.callee.name === localName
+      if (!isBare && !isCall) continue
+      if (setupFn) {
+        if (isCall && (el as t.CallExpression).arguments.length > 0) {
+          warnings.push(
+            '`initialize(...)` options could not be folded: the existing `addonMsw(...)` already receives a setup function. Merge them by hand.'
+          )
+          return 'conflict'
+        }
+        if (isCall) {
+          ;(el as t.CallExpression).arguments.push(setupFn)
+          return 'changed'
+        }
+      }
+      // Registered and nothing to fold — done.
+      return 'unchanged'
+    }
+  }
+
+  // Not registered yet — ensure the default import and inject the call.
+  if (!localName) {
+    localName = 'addonMsw'
+    let attached = false
+    for (const stmt of parsed._ast.program.body) {
+      if (!t.isImportDeclaration(stmt)) continue
+      if (stmt.source.value !== ADDON_PACKAGE) continue
+      stmt.specifiers.unshift(t.importDefaultSpecifier(t.identifier(localName)))
+      attached = true
+      break
+    }
+    if (!attached) {
+      parsed._ast.program.body.unshift(
+        t.importDeclaration(
+          [t.importDefaultSpecifier(t.identifier(localName))],
+          t.stringLiteral(ADDON_PACKAGE)
+        )
+      )
+    }
+  }
+
+  const call = t.callExpression(
+    t.identifier(localName),
+    setupFn ? [setupFn] : []
+  )
+
+  if (!addonsProp) {
+    configObj.properties.unshift(
+      t.objectProperty(t.identifier('addons'), t.arrayExpression([call]))
+    )
+    return 'changed'
+  }
+  if (!addonsArray) {
+    warnings.push(
+      '`addons` in definePreview is not an array literal; register `addonMsw()` by hand.'
+    )
+    return 'conflict'
+  }
+  addonsArray.elements.unshift(call)
+  return 'changed'
+}
+
+// -------- opt-in: preview-level `parameters.msw` → `beforeEach`
+
+function migratePreviewParameters(
+  previewObj: t.ObjectExpression,
+  warnings: string[]
+): boolean {
+  const parametersProp = findObjectProperty(previewObj, 'parameters')
+  if (!parametersProp || !t.isObjectExpression(parametersProp.value))
+    return false
+  const parameters = parametersProp.value
+  const mswProp = findObjectProperty(parameters, 'msw')
+  if (!mswProp) return false
+
+  const handlers = extractHandlers(mswProp.value)
+  if (!handlers) {
+    warnings.push(
+      'Preview-level `parameters.msw` has a shape the codemod does not recognise; migrate it to `beforeEach({ msw })` by hand.'
+    )
+    return false
+  }
+
+  if (handlers.length > 0 && hasAnyProperty(previewObj, 'beforeEach')) {
+    warnings.push(
+      'The preview already defines `beforeEach`; merge the `parameters.msw` handlers into it by hand.'
+    )
+    return false
+  }
+
+  if (handlers.length > 0) {
+    const beforeEachProp = buildBeforeEachProperty(handlers)
+    const insertIdx = previewObj.properties.indexOf(parametersProp)
+    previewObj.properties.splice(insertIdx, 0, beforeEachProp)
+  }
+  // An empty handler list (`msw: []`) is simply dropped.
+
+  parameters.properties = parameters.properties.filter((p) => p !== mswProp)
+  if (parameters.properties.length === 0) {
+    previewObj.properties = previewObj.properties.filter(
+      (p) => p !== parametersProp
+    )
+  }
+  return true
+}
+
+// -------- helpers
+
+function removeStatement(body: t.Statement[], stmt: t.Statement): void {
+  const idx = body.indexOf(stmt)
+  if (idx !== -1) body.splice(idx, 1)
+}

--- a/codemod/src/transforms/stories.ts
+++ b/codemod/src/transforms/stories.ts
@@ -1,0 +1,434 @@
+/**
+ * Story-file transform.
+ * Migrates `parameters.msw.handlers` (and its legacy shapes) into a
+ * `beforeEach({ msw }) { msw.use(...) }` annotation. Idempotent: a file
+ * that no longer carries `parameters.msw` is left untouched.
+ * Only shapes the transform can prove safe are rewritten:
+ *   - `RequestHandler[]` (legacy array form)
+ *   - `{ handlers: RequestHandler[] }`
+ *   - `{ handlers: Record<string, RequestHandler | RequestHandler[]> }`
+ * Anything else (custom keys, dynamic values, etc.) is skipped while
+ * the user gets a warning to migrate by hand.
+ * CSF3 (story-as-object) and CSF2 (post-export `Story.parameters = ...` annotation) are both handled.
+ */
+
+import { recast, types as t } from 'storybook/internal/babel'
+import {
+  babelParse,
+  type CsfFile,
+  loadCsf,
+  printCsf
+} from 'storybook/internal/csf-tools'
+
+export interface StoryTransformResult {
+  /** Transformed source, or null when no changes were needed. */
+  code: string | null
+  /** Names of stories/files we refused to migrate because the
+   *  `parameters.msw` shape wasn't recognisable. The CLI surfaces these
+   *  as warnings so the user can hand-migrate. */
+  skippedStories: string[]
+}
+
+export function transformStory(source: string): StoryTransformResult {
+  const skipped: string[] = []
+  let parsed: CsfFile
+  try {
+    parsed = loadCsf(source, {
+      makeTitle: (title?: string) => title || 'default'
+    }).parse()
+  } catch {
+    // Not parseable as CSF — leave alone.
+    return { code: null, skippedStories: [] }
+  }
+
+  let changed = false
+
+  // CSF3: meta export + each story export are object literals — walk them.
+  for (const [name, decl] of Object.entries(parsed._storyExports)) {
+    const obj = getStoryObject(decl)
+    if (!obj) continue
+    const result = migrateMswOnObject(obj, name)
+    if (result === 'changed') changed = true
+    if (result === 'skipped') skipped.push(name)
+  }
+  if (parsed._metaPath) {
+    const meta = resolveStoryObject(parsed, parsed._metaPath.node)
+    if (meta) {
+      const result = migrateMswOnObject(meta, 'meta')
+      if (result === 'changed') changed = true
+      if (result === 'skipped') skipped.push('meta')
+    }
+  }
+
+  // CSF2: `Story.parameters = { msw: ... }` annotation statements at the
+  // top level of the file. The RHS of that assignment IS the parameters
+  // object — not a story object — so we need a different emit path that
+  // produces a parallel `Story.beforeEach = ({ msw }) => { msw.use(...) }`
+  // annotation rather than mutating an enclosing object literal.
+  for (let i = parsed._ast.program.body.length - 1; i >= 0; i--) {
+    const stmt = parsed._ast.program.body[i]
+    if (!isCsf2Annotation(stmt, parsed._storyExports)) continue
+    const assign = (stmt as t.ExpressionStatement)
+      .expression as t.AssignmentExpression
+    const left = assign.left as t.MemberExpression
+    const storyName = (left.object as t.Identifier).name
+    const propName =
+      (t.isIdentifier(left.property) && left.property.name) ||
+      (t.isStringLiteral(left.property) && left.property.value) ||
+      null
+    if (propName !== 'parameters' && propName !== 'story') continue
+    if (!t.isObjectExpression(assign.right)) continue
+    const result = migrateCsf2Annotation(
+      parsed,
+      stmt as t.ExpressionStatement,
+      storyName,
+      i,
+      propName
+    )
+    if (result === 'changed') changed = true
+    if (result === 'skipped') skipped.push(storyName)
+  }
+
+  if (!changed) {
+    return { code: null, skippedStories: skipped }
+  }
+  return { code: printCsf(parsed).code, skippedStories: skipped }
+}
+
+// -------- per-object migration
+
+type MigrationOutcome = 'changed' | 'skipped' | 'noop'
+
+function migrateMswOnObject(
+  obj: t.ObjectExpression,
+  storyName: string
+): MigrationOutcome {
+  const parametersProp = findObjectProperty(obj, 'parameters')
+  if (!parametersProp || !t.isObjectExpression(parametersProp.value))
+    return 'noop'
+  const parameters = parametersProp.value
+  const mswProp = findObjectProperty(parameters, 'msw')
+  if (!mswProp) return 'noop'
+
+  const extracted = extractHandlers(mswProp.value)
+  if (!extracted) {
+    // Unrecognised shape — leave the file alone for THIS story.
+    return 'skipped'
+  }
+
+  // Refuse to silently overwrite an existing beforeEach. The user will
+  // hand-merge; we'd rather skip than blow away their code. `beforeEach`
+  // can appear as either a regular property (`beforeEach: () => {}`) or
+  // the method shorthand (`beforeEach() {}`); check for both.
+  if (extracted.length > 0 && hasAnyProperty(obj, 'beforeEach'))
+    return 'skipped'
+
+  if (extracted.length > 0) {
+    const beforeEachProp = buildBeforeEachProperty(extracted)
+    // Inserted BEFORE parameters so the migrated file reads naturally.
+    const insertIdx = obj.properties.indexOf(parametersProp)
+    obj.properties.splice(insertIdx, 0, beforeEachProp)
+  }
+  // An empty handler list (`msw: []`) has nothing to carry over — the
+  // parameter is simply dropped.
+
+  // Strip `msw` from `parameters`; drop `parameters` itself if empty.
+  parameters.properties = parameters.properties.filter((p) => p !== mswProp)
+  if (parameters.properties.length === 0) {
+    obj.properties = obj.properties.filter((p) => p !== parametersProp)
+  }
+  return 'changed'
+}
+
+// -------- handler extraction
+//
+// Returns an array of Expressions to spread into `msw.use(...)`, or null
+// if the shape isn't one we know how to migrate.
+
+export function extractHandlers(
+  value: t.Expression | t.PatternLike
+): t.Expression[] | null {
+  // Legacy array form: `parameters: { msw: [...handlers] }`
+  if (t.isArrayExpression(value)) {
+    return collectArrayElements(value)
+  }
+  // Object form: `parameters: { msw: { handlers: ... } }`
+  if (t.isObjectExpression(value)) {
+    const handlersProp = findObjectProperty(value, 'handlers')
+    if (!handlersProp) return null
+    const hv = handlersProp.value
+    // `handlers: [h1, h2]`
+    if (t.isArrayExpression(hv)) return collectArrayElements(hv)
+    // `handlers: { name1: h, name2: [h, h] }` — flatten the values.
+    if (t.isObjectExpression(hv)) {
+      const acc: t.Expression[] = []
+      for (const prop of hv.properties) {
+        if (!t.isObjectProperty(prop)) return null // spread/computed → unsupported
+        if (t.isArrayExpression(prop.value)) {
+          const elems = collectArrayElements(prop.value)
+          if (!elems) return null
+          acc.push(...elems)
+        } else if (isHandlerLikeExpression(prop.value)) {
+          acc.push(prop.value as t.Expression)
+        } else {
+          return null
+        }
+      }
+      return acc
+    }
+    return null
+  }
+  return null
+}
+
+function collectArrayElements(arr: t.ArrayExpression): t.Expression[] | null {
+  const acc: t.Expression[] = []
+  for (const el of arr.elements) {
+    if (el === null) return null // sparse array
+    if (t.isSpreadElement(el)) {
+      // Allow spreads like `...sharedHandlers` to flow through.
+      acc.push(el as unknown as t.Expression)
+      continue
+    }
+    if (!isHandlerLikeExpression(el)) return null
+    acc.push(el as t.Expression)
+  }
+  return acc
+}
+
+function isHandlerLikeExpression(node: t.Node): boolean {
+  // Anything that can sensibly be spread into `msw.use(...)` — calls,
+  // identifiers, member expressions, conditionals, etc. Reject literal
+  // primitives so we don't migrate something obviously wrong.
+  return (
+    !t.isStringLiteral(node) &&
+    !t.isNumericLiteral(node) &&
+    !t.isBooleanLiteral(node)
+  )
+}
+
+// -------- AST builders
+//
+// The `beforeEach` shells are parsed from source templates WITH recast so
+// they keep original tokens and print compactly (`beforeEach({ msw })`);
+// nodes built via `t.*` get exploded across lines by recast's pretty
+// printer. Only the `msw.use(...)` arguments are spliced in.
+
+function parseTemplate(template: string): t.ObjectExpression {
+  const parsed = recast.parse(template, {
+    parser: { parse: (source: string) => babelParse(source) }
+  }) as { program: t.Program }
+  const stmt = parsed.program.body[0] as t.ExpressionStatement
+  return stmt.expression as t.ObjectExpression
+}
+
+export function buildBeforeEachProperty(
+  handlers: t.Expression[]
+): t.ObjectMethod {
+  // beforeEach({ msw }) { msw.use(...handlers) }
+  const obj = parseTemplate(
+    '({\n  beforeEach({ msw }) {\n    msw.use()\n  }\n})'
+  )
+  const method = obj.properties[0] as t.ObjectMethod
+  const call = (method.body.body[0] as t.ExpressionStatement)
+    .expression as t.CallExpression
+  call.arguments.push(...(handlers as (t.Expression | t.SpreadElement)[]))
+  return method
+}
+
+export function buildBeforeEachArrow(
+  handlers: t.Expression[]
+): t.ArrowFunctionExpression {
+  // ({ msw }) => { msw.use(...handlers) }
+  const obj = parseTemplate(
+    '({\n  beforeEach: ({ msw }) => {\n    msw.use()\n  }\n})'
+  )
+  const prop = obj.properties[0] as t.ObjectProperty
+  const arrow = prop.value as t.ArrowFunctionExpression
+  const body = arrow.body as t.BlockStatement
+  const call = (body.body[0] as t.ExpressionStatement)
+    .expression as t.CallExpression
+  call.arguments.push(...(handlers as (t.Expression | t.SpreadElement)[]))
+  return arrow
+}
+
+// -------- helpers
+
+export function findObjectProperty(
+  obj: t.ObjectExpression,
+  name: string
+): t.ObjectProperty | undefined {
+  for (const prop of obj.properties) {
+    if (!t.isObjectProperty(prop)) continue
+    const key = prop.key
+    if (t.isIdentifier(key) && key.name === name) return prop
+    if (t.isStringLiteral(key) && key.value === name) return prop
+  }
+  return undefined
+}
+
+// Like findObjectProperty but also matches `name() {}` method shorthand.
+export function hasAnyProperty(obj: t.ObjectExpression, name: string): boolean {
+  for (const prop of obj.properties) {
+    if (t.isObjectProperty(prop) || t.isObjectMethod(prop)) {
+      const key = prop.key
+      if (t.isIdentifier(key) && key.name === name) return true
+      if (t.isStringLiteral(key) && key.value === name) return true
+    }
+  }
+  return false
+}
+
+function getStoryObject(node: t.Node): t.ObjectExpression | undefined {
+  if (t.isVariableDeclarator(node)) {
+    let init = node.init
+    if (t.isTSSatisfiesExpression(init) || t.isTSAsExpression(init))
+      init = init.expression
+    if (init && t.isObjectExpression(init)) return init
+  } else if (t.isExportDefaultDeclaration(node)) {
+    let init: t.Node | null | undefined = node.declaration
+    if (init && (t.isTSSatisfiesExpression(init) || t.isTSAsExpression(init)))
+      init = init.expression
+    if (init && t.isObjectExpression(init)) return init
+  }
+  return undefined
+}
+
+// Resolve a "story object" through one level of indirection.
+//
+// CSF3 meta is commonly:
+//
+//     const meta = { ... }
+//     export default meta
+//
+// The CsfFile's `_metaPath` for that shape points at the
+// `export default meta` declaration, whose `.declaration` is an
+// `Identifier`. We follow the identifier back to its variable declarator
+// in the file's top-level body and return the underlying ObjectExpression.
+function resolveStoryObject(
+  parsed: CsfFile,
+  node: t.Node
+): t.ObjectExpression | undefined {
+  const direct = getStoryObject(node)
+  if (direct) return direct
+  if (t.isExportDefaultDeclaration(node)) {
+    let decl: t.Node | null | undefined = node.declaration
+    if (decl && (t.isTSSatisfiesExpression(decl) || t.isTSAsExpression(decl))) {
+      decl = decl.expression
+    }
+    if (decl && t.isIdentifier(decl)) {
+      const ref = findVariableDeclarator(parsed, decl.name)
+      if (ref) return getStoryObject(ref)
+    }
+  }
+  return undefined
+}
+
+function findVariableDeclarator(
+  parsed: CsfFile,
+  name: string
+): t.VariableDeclarator | undefined {
+  for (const stmt of parsed._ast.program.body) {
+    const decl = t.isExportNamedDeclaration(stmt) ? stmt.declaration : stmt
+    if (!decl || !t.isVariableDeclaration(decl)) continue
+    for (const d of decl.declarations) {
+      if (t.isIdentifier(d.id) && d.id.name === name) return d
+    }
+  }
+  return undefined
+}
+
+// CSF2 annotations, in both historical forms:
+//
+//   Foo.parameters = { msw: { handlers: [...] } }
+//   Foo.story = { parameters: { msw: { handlers: [...] } } }   (v1 style)
+//
+// We can't inject `beforeEach` into a story object (the export is a
+// function, not an object literal), so we emit a parallel sibling
+// annotation: `Foo.beforeEach = ({ msw }) => { msw.use(...) }`.
+function migrateCsf2Annotation(
+  parsed: CsfFile,
+  stmt: t.ExpressionStatement,
+  storyName: string,
+  stmtIndex: number,
+  form: 'parameters' | 'story'
+): MigrationOutcome {
+  const assign = stmt.expression as t.AssignmentExpression
+  const container = assign.right as t.ObjectExpression
+
+  let parametersObj: t.ObjectExpression
+  let storyParametersProp: t.ObjectProperty | undefined
+  if (form === 'parameters') {
+    parametersObj = container
+  } else {
+    storyParametersProp = findObjectProperty(container, 'parameters')
+    if (!storyParametersProp || !t.isObjectExpression(storyParametersProp.value)) {
+      return 'noop'
+    }
+    parametersObj = storyParametersProp.value
+  }
+
+  const mswProp = findObjectProperty(parametersObj, 'msw')
+  if (!mswProp) return 'noop'
+
+  // csf-tools collects every `Foo.<key> = ...` assignment (and the keys of
+  // a v1 `Foo.story = {...}` object) into `_storyAnnotations` — the
+  // authoritative place to check for an existing `beforeEach`.
+  if (parsed._storyAnnotations[storyName]?.beforeEach != null) {
+    return 'skipped'
+  }
+
+  const handlers = extractHandlers(mswProp.value)
+  if (!handlers) return 'skipped'
+
+  // Strip `msw` from the parameters object, then unwind empty containers:
+  // an emptied `parameters` comes off the story object; an emptied
+  // statement is dropped. An empty handler list has nothing to carry over,
+  // so no `beforeEach` sibling is emitted for it.
+  parametersObj.properties = parametersObj.properties.filter(
+    (p) => p !== mswProp
+  )
+  if (
+    storyParametersProp &&
+    parametersObj.properties.length === 0
+  ) {
+    container.properties = container.properties.filter(
+      (p) => p !== storyParametersProp
+    )
+  }
+  const statementEmptied = container.properties.length === 0
+
+  if (handlers.length === 0) {
+    if (statementEmptied) {
+      parsed._ast.program.body.splice(stmtIndex, 1)
+    }
+    return 'changed'
+  }
+
+  const beforeEachAssign = t.expressionStatement(
+    t.assignmentExpression(
+      '=',
+      t.memberExpression(t.identifier(storyName), t.identifier('beforeEach')),
+      buildBeforeEachArrow(handlers)
+    )
+  )
+
+  if (statementEmptied) {
+    parsed._ast.program.body.splice(stmtIndex, 1, beforeEachAssign)
+  } else {
+    parsed._ast.program.body.splice(stmtIndex + 1, 0, beforeEachAssign)
+  }
+  return 'changed'
+}
+
+function isCsf2Annotation(
+  stmt: t.Statement,
+  storyExports: Record<string, unknown>
+): boolean {
+  if (!t.isExpressionStatement(stmt)) return false
+  const expr = stmt.expression
+  if (!t.isAssignmentExpression(expr)) return false
+  if (!t.isMemberExpression(expr.left)) return false
+  if (!t.isIdentifier(expr.left.object)) return false
+  return Boolean(storyExports[expr.left.object.name])
+}

--- a/codemod/src/transforms/stories.ts
+++ b/codemod/src/transforms/stories.ts
@@ -20,17 +20,24 @@ import {
   printCsf
 } from 'storybook/internal/csf-tools'
 
+/** Why a story was left alone. The CLI phrases its guidance per reason. */
+export type SkipReason = 'unrecognized-shape' | 'existing-before-each'
+
+export interface SkippedStory {
+  story: string
+  reason: SkipReason
+}
+
 export interface StoryTransformResult {
   /** Transformed source, or null when no changes were needed. */
   code: string | null
-  /** Names of stories/files we refused to migrate because the
-   *  `parameters.msw` shape wasn't recognisable. The CLI surfaces these
-   *  as warnings so the user can hand-migrate. */
-  skippedStories: string[]
+  /** Stories we refused to migrate, with the reason. The CLI surfaces
+   *  these as warnings so the user can migrate them themselves. */
+  skippedStories: SkippedStory[]
 }
 
 export function transformStory(source: string): StoryTransformResult {
-  const skipped: string[] = []
+  const skipped: SkippedStory[] = []
   let parsed: CsfFile
   try {
     parsed = loadCsf(source, {
@@ -49,14 +56,14 @@ export function transformStory(source: string): StoryTransformResult {
     if (!obj) continue
     const result = migrateMswOnObject(obj, name)
     if (result === 'changed') changed = true
-    if (result === 'skipped') skipped.push(name)
+    else if (result !== 'noop') skipped.push({ story: name, reason: result })
   }
   if (parsed._metaPath) {
     const meta = resolveStoryObject(parsed, parsed._metaPath.node)
     if (meta) {
       const result = migrateMswOnObject(meta, 'meta')
       if (result === 'changed') changed = true
-      if (result === 'skipped') skipped.push('meta')
+      else if (result !== 'noop') skipped.push({ story: 'meta', reason: result })
     }
   }
 
@@ -86,7 +93,7 @@ export function transformStory(source: string): StoryTransformResult {
       propName
     )
     if (result === 'changed') changed = true
-    if (result === 'skipped') skipped.push(storyName)
+    else if (result !== 'noop') skipped.push({ story: storyName, reason: result })
   }
 
   if (!changed) {
@@ -97,7 +104,7 @@ export function transformStory(source: string): StoryTransformResult {
 
 // -------- per-object migration
 
-type MigrationOutcome = 'changed' | 'skipped' | 'noop'
+type MigrationOutcome = 'changed' | 'noop' | SkipReason
 
 function migrateMswOnObject(
   obj: t.ObjectExpression,
@@ -113,15 +120,16 @@ function migrateMswOnObject(
   const extracted = extractHandlers(mswProp.value)
   if (!extracted) {
     // Unrecognised shape — leave the file alone for THIS story.
-    return 'skipped'
+    return 'unrecognized-shape'
   }
 
-  // Refuse to silently overwrite an existing beforeEach. The user will
-  // hand-merge; we'd rather skip than blow away their code. `beforeEach`
-  // can appear as either a regular property (`beforeEach: () => {}`) or
-  // the method shorthand (`beforeEach() {}`); check for both.
+  // Refuse to silently overwrite an existing beforeEach. The user merges
+  // the handlers into it themselves; we'd rather skip than blow away their
+  // code. `beforeEach` can appear as either a regular property
+  // (`beforeEach: () => {}`) or the method shorthand (`beforeEach() {}`);
+  // check for both.
   if (extracted.length > 0 && hasAnyProperty(obj, 'beforeEach'))
-    return 'skipped'
+    return 'existing-before-each'
 
   if (extracted.length > 0) {
     const beforeEachProp = buildBeforeEachProperty(extracted)
@@ -375,11 +383,11 @@ function migrateCsf2Annotation(
   // a v1 `Foo.story = {...}` object) into `_storyAnnotations` — the
   // authoritative place to check for an existing `beforeEach`.
   if (parsed._storyAnnotations[storyName]?.beforeEach != null) {
-    return 'skipped'
+    return 'existing-before-each'
   }
 
   const handlers = extractHandlers(mswProp.value)
-  if (!handlers) return 'skipped'
+  if (!handlers) return 'unrecognized-shape'
 
   // Strip `msw` from the parameters object, then unwind empty containers:
   // an emptied `parameters` comes off the story object; an emptied

--- a/codemod/src/transforms/stories.ts
+++ b/codemod/src/transforms/stories.ts
@@ -58,8 +58,16 @@ export function transformStory(source: string): StoryTransformResult {
     if (result === 'changed') changed = true
     else if (result !== 'noop') skipped.push({ story: name, reason: result })
   }
-  if (parsed._metaPath) {
-    const meta = resolveStoryObject(parsed, parsed._metaPath.node)
+  // CSF3 metas are default-exported (`_metaPath`); CSF factory metas are
+  // plain variables (`const meta = preview.meta({...})`) tracked only by
+  // name in `_metaVariableName`.
+  const metaNode =
+    parsed._metaPath?.node ??
+    (parsed._metaVariableName
+      ? findVariableDeclarator(parsed, parsed._metaVariableName)
+      : undefined)
+  if (metaNode) {
+    const meta = resolveStoryObject(parsed, metaNode)
     if (meta) {
       const result = migrateMswOnObject(meta, 'meta')
       if (result === 'changed') changed = true
@@ -293,11 +301,30 @@ function getStoryObject(node: t.Node): t.ObjectExpression | undefined {
     if (t.isTSSatisfiesExpression(init) || t.isTSAsExpression(init))
       init = init.expression
     if (init && t.isObjectExpression(init)) return init
+    if (init) return unwrapFactoryCall(init)
   } else if (t.isExportDefaultDeclaration(node)) {
     let init: t.Node | null | undefined = node.declaration
     if (init && (t.isTSSatisfiesExpression(init) || t.isTSAsExpression(init)))
       init = init.expression
     if (init && t.isObjectExpression(init)) return init
+  }
+  return undefined
+}
+
+// CSF factories wrap the annotations object in a call:
+// `preview.meta({...})` and `meta.story({...})`. An argument-less
+// `meta.story()` has nothing to migrate.
+function unwrapFactoryCall(node: t.Node): t.ObjectExpression | undefined {
+  if (
+    t.isCallExpression(node) &&
+    t.isMemberExpression(node.callee) &&
+    t.isIdentifier(node.callee.property) &&
+    (node.callee.property.name === 'meta' ||
+      node.callee.property.name === 'story') &&
+    node.arguments[0] != null &&
+    t.isObjectExpression(node.arguments[0])
+  ) {
+    return node.arguments[0]
   }
   return undefined
 }

--- a/codemod/tsconfig.json
+++ b/codemod/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./src", "./__tests__"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "jsx": "preserve",
+    "lib": ["ES2024"],
+    "types": ["node"]
+  }
+}

--- a/codemod/vitest.config.ts
+++ b/codemod/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "./types": "./build/types.d.mts",
     "./csf3": "./build/csf3.mjs"
   },
+  "bin": {
+    "msw-storybook-migrate": "./build/migrate.mjs"
+  },
   "storybook": {
     "displayName": "Mock Service Worker",
     "icon": "https://mswjs.io/msw-storybook-addon.png"
@@ -23,6 +26,7 @@
     "test:stories": "playwright test",
     "test:play": "vitest -c ./tests/factory/vitest.config.ts --project storybook",
     "test:ts": "vitest --typecheck",
+    "test:codemod": "vitest run -c ./codemod/vitest.config.ts",
     "build": "tsdown",
     "release": "release publish"
   },
@@ -64,6 +68,7 @@
     "publint": "^0.3.21",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "ts-dedent": "^2.3.0",
     "storybook": "^10.3.4",
     "tsdown": "^0.22.3",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       storybook:
         specifier: ^10.3.4
         version: 10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ts-dedent:
+        specifier: ^2.3.0
+        version: 2.3.0
       tsdown:
         specifier: ^0.22.3
         version: 0.22.3(publint@0.3.21)(typescript@5.9.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
@@ -2020,8 +2023,8 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  ts-dedent@2.2.0:
-    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
     engines: {node: '>=6.10'}
 
   tsconfig-paths@4.2.0:
@@ -2825,7 +2828,7 @@ snapshots:
     dependencies:
       '@storybook/csf-plugin': 10.3.4(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.12.2))
       storybook: 10.3.4(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      ts-dedent: 2.2.0
+      ts-dedent: 2.3.0
       vite: 7.3.1(@types/node@24.12.2)
     transitivePeerDependencies:
       - esbuild
@@ -4074,7 +4077,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-dedent@2.2.0: {}
+  ts-dedent@2.3.0: {}
 
   tsconfig-paths@4.2.0:
     dependencies:

--- a/src/csf3.ts
+++ b/src/csf3.ts
@@ -41,7 +41,7 @@ let hasPrintedDeprecationWarning = false
 function printDeprecationWarning() {
   if (!hasPrintedDeprecationWarning) {
     console.warn(
-      '[msw-storybook-addon] The loader API (CSF3) is deprecated and will be removed in the future major release. Run `npx msw-storybook-migrate` to migrate.'
+      '[msw-storybook-addon] The loader API (CSF3) is deprecated and will be removed in the next major release. Run `npx msw-storybook-migrate` to migrate. Learn more: https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#from-2xx-to-3xx'
     )
     hasPrintedDeprecationWarning = true
   }

--- a/src/csf3.ts
+++ b/src/csf3.ts
@@ -51,7 +51,10 @@ let mswInstancePromise: Promise<MswApi> | undefined
 
 /**
  * Create a loader to initialize Mock Service Worker.
- * @deprecated Use the preview annotations (`addonMsw()`) instead.
+ * @deprecated Use the preview annotations (`addonMsw()`) with CSF Next instead. Run
+ * `npx msw-storybook-migrate` to migrate automatically. See the
+ * {@link https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#from-2xx-to-3xx migration guide}
+ * for details.
  *
  * @example
  * // .storybook/preview.ts

--- a/src/csf3.ts
+++ b/src/csf3.ts
@@ -41,7 +41,7 @@ let hasPrintedDeprecationWarning = false
 function printDeprecationWarning() {
   if (!hasPrintedDeprecationWarning) {
     console.warn(
-      '[msw-storybook-addon] The loader API (CSF3) is deprecated and will be removed in the next major release. Run `npx msw-storybook-migrate` to migrate. Learn more: https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#from-2xx-to-3xx'
+      '[msw-storybook-addon] `mswLoader` is deprecated when using CSF Next — use `addonMsw()` instead. Run `npx msw-storybook-migrate` to migrate.\n\nLearn more: https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#from-2xx-to-3xx'
     )
     hasPrintedDeprecationWarning = true
   }
@@ -50,9 +50,11 @@ function printDeprecationWarning() {
 let mswInstancePromise: Promise<MswApi> | undefined
 
 /**
- * Create a loader to initialize Mock Service Worker.
- * @deprecated Use the preview annotations (`addonMsw()`) with CSF Next instead. Run
- * `npx msw-storybook-migrate` to migrate automatically. See the
+ * Create a loader to initialize Mock Service Worker. This is the supported
+ * integration for CSF 3.0 projects.
+ *
+ * Deprecated when using CSF Next: use the preview annotations (`addonMsw()`)
+ * instead. Run `npx msw-storybook-migrate` to migrate automatically. See the
  * {@link https://github.com/mswjs/msw-storybook-addon/blob/main/MIGRATION.md#from-2xx-to-3xx migration guide}
  * for details.
  *
@@ -71,7 +73,12 @@ export function mswLoader(
   setup: SetupFunction = defaultSetup
 ): LoaderFunction<Renderer> {
   return async (context) => {
-    printDeprecationWarning()
+    // CSF Next's `meta()` stamps `csfFactory: true` on story parameters —
+    // the loader is only deprecated for CSF Next projects, so CSF 3.0
+    // users never see the warning.
+    if (context.parameters.csfFactory === true) {
+      printDeprecationWarning()
+    }
 
     const worker = await (mswInstancePromise ??= Promise.resolve(setup()))
     context.msw = worker

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,14 +1,25 @@
 import { defineConfig } from 'tsdown'
 
-export default defineConfig({
-  entry: [
-    './src/index.ts',
-    './src/preview.ts',
-    './src/types.ts',
-    './src/csf3.ts',
-  ],
-  outDir: './build',
-  format: ['esm'],
-  dts: true,
-  clean: true,
-})
+export default defineConfig([
+  {
+    entry: [
+      './src/index.ts',
+      './src/preview.ts',
+      './src/types.ts',
+      './src/csf3.ts'
+    ],
+    outDir: './build',
+    format: ['esm'],
+    dts: true,
+    clean: true
+  },
+  // For the `msw-storybook-migrate` command
+  {
+    entry: { migrate: './codemod/src/bin.ts' },
+    outDir: './build',
+    format: ['esm'],
+    platform: 'node',
+    dts: false,
+    clean: false
+  }
+])


### PR DESCRIPTION
This PR adds a codemod to assist migrating: `npx msw-storybook-migrate`. It's part of the addon itself so users have to have the addon installed. It's not a problem because every user will have the package in their project.

### What it migrates (v2 → v3)

1. `loaders: [mswLoader]` → `loaders: [mswLoader()]`, imported from `msw-storybook-addon/csf3`
2. `mswDecorator` → the loader
3. `initialize(options, initialHandlers)` → removed, and options moved into a setup function passed to `mswLoader(setup)` / `addonMsw(setup)`
4. Registers the addon in `main.ts` addons field
5. Opt-in (users get prompted): `parameters.msw` → `beforeEach({ msw })` in stories (CSF2 and CSF3, including v1-style Foo.story) and preview file

### The weird catch

Migrating the addon and migrating to CSF Next are two separate migrations, and users can do them in either order. That's just the hard reality of CSF3 + CSF4, and it creates three scenarios:

1. Migrate old addon → new addon and stay on CSF3. That's it.
2. Migrate CSF3 → CSF Next first, then run the codemod — the addon gets wired via `addonMsw()` directly.
3. Migrate old addon → new addon on CSF3, then move to CSF Next later. Now the addon setup is incompatible: the loader wiring gets carried into `definePreview`, and the csf-factories codemod injects a `import * as x from 'msw-storybook-addon/preview'` entry into `addons`, which is a no-op in v3.

The codemod accommodates all three. Meaning you can run it in any of the scenarios, and you can run it multiple times.

The PR also updates the loader deprecation warning to point at the codemod and the migration guide.